### PR TITLE
Travis CI: OpenJDK 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: java
 jdk:
 - openjdk8
 - oraclejdk8
+- openjdk11
 addons:
   apt:
     packages:


### PR DESCRIPTION
PR adds `openjdk11` to Travis CI build matrix :tada: 