### PR TITLE
Add jacoco integration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,12 +10,39 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+
+    <!-- Plugin versions -->
+    <version.jacoco-maven-plugin>0.8.2</version.jacoco-maven-plugin>
   </properties>
   
   <modules>
     <module>dc-model</module>
     <module>dc-model-jackson</module>
   </modules>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+        <version>${version.jacoco-maven-plugin}</version>
+        <executions>
+          <execution>
+            <id>pre-unit-test</id>
+            <goals>
+              <goal>prepare-agent</goal>
+            </goals>
+          </execution>
+          <execution>
+            <phase>test</phase>
+            <goals>
+              <goal>report</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
 
   <distributionManagement>
     <snapshotRepository>


### PR DESCRIPTION
This PR adds `jacoco` for code coverage. It also enables `codecov` information on GitHub.