### PR TITLE
Security alert: update version of jackson

### DIFF
--- a/dc-model-jackson/pom.xml
+++ b/dc-model-jackson/pom.xml
@@ -15,7 +15,7 @@
   <properties>
     <version.assertj-core>3.11.1</version.assertj-core>
     <version.commons-beanutils>1.9.3</version.commons-beanutils>
-    <version.jackson>2.9.7</version.jackson>
+    <version.jackson>2.9.8</version.jackson>
     <version.junit-jupiter-api>5.3.1</version.junit-jupiter-api>
     <version.junit-jupiter-engine>5.3.1</version.junit-jupiter-engine>
     <version.logback-classic>1.2.3</version.logback-classic>


### PR DESCRIPTION
This PR updates the version of `jackson` to fix CVE-2018-19360, CVE-2018-19362 and CVE-2018-19361.

This was found during a GitHub Security Scan.