### PR TITLE
Fix return type

### DIFF
--- a/dc-model-jackson/pom.xml
+++ b/dc-model-jackson/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>de.digitalcollections.model</groupId>
     <artifactId>dc-model-parent</artifactId>
-    <version>4.0.0</version>
+    <version>4.0.1</version>
   </parent>
 
   <name>DigitalCollections: Model (Jackson)</name>

--- a/dc-model-xml/pom.xml
+++ b/dc-model-xml/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>de.digitalcollections.model</groupId>
     <artifactId>dc-model-parent</artifactId>
-    <version>4.0.0</version>
+    <version>4.0.1</version>
   </parent>
 
   <name>DigitalCollections: Model (XML)</name>

--- a/dc-model/pom.xml
+++ b/dc-model/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>de.digitalcollections.model</groupId>
     <artifactId>dc-model-parent</artifactId>
-    <version>4.0.0</version>
+    <version>4.0.1</version>
   </parent>
 
   <name>DigitalCollections: Model (Model)</name>

--- a/dc-model/src/main/java/de/digitalcollections/model/api/identifiable/parts/LocalizedText.java
+++ b/dc-model/src/main/java/de/digitalcollections/model/api/identifiable/parts/LocalizedText.java
@@ -1,6 +1,6 @@
 package de.digitalcollections.model.api.identifiable.parts;
 
-import java.util.Collection;
+import java.util.ArrayList;
 import java.util.Locale;
 import java.util.Map;
 
@@ -8,7 +8,7 @@ import java.util.Map;
 public interface LocalizedText extends Map<Locale, String> {
 
   /** @return all locales for which translated texts are available. */
-  Collection<Locale> getLocales();
+  ArrayList<Locale> getLocales();
 
   /** @return first found text */
   String getText();

--- a/dc-model/src/main/java/de/digitalcollections/model/impl/identifiable/parts/LocalizedTextImpl.java
+++ b/dc-model/src/main/java/de/digitalcollections/model/impl/identifiable/parts/LocalizedTextImpl.java
@@ -1,9 +1,8 @@
 package de.digitalcollections.model.impl.identifiable.parts;
 
 import de.digitalcollections.model.api.identifiable.parts.LocalizedText;
-import java.util.Collection;
+import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.LinkedHashSet;
 import java.util.Locale;
 
 public class LocalizedTextImpl extends HashMap<Locale, String> implements LocalizedText {
@@ -18,13 +17,13 @@ public class LocalizedTextImpl extends HashMap<Locale, String> implements Locali
   }
 
   @Override
-  public Collection<Locale> getLocales() {
-    return new LinkedHashSet<>(this.keySet());
+  public ArrayList<Locale> getLocales() {
+    return new ArrayList<>(this.keySet());
   }
 
   @Override
   public String getText() {
-    Collection<Locale> locales = getLocales();
+    ArrayList<Locale> locales = getLocales();
     if (locales.isEmpty()) {
       return null;
     }

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>de.digitalcollections.model</groupId>
   <artifactId>dc-model-parent</artifactId>
-  <version>4.0.0</version>
+  <version>4.0.1</version>
   <packaging>pom</packaging>
 
   <modules>


### PR DESCRIPTION
This PR fixes the return type of the method `getLocales` in the `LocalizedText` class to `ArrayList`.