### PR TITLE
Fix npe

### DIFF
--- a/dc-model/src/main/java/de/digitalcollections/model/impl/identifiable/resource/FileResourceImpl.java
+++ b/dc-model/src/main/java/de/digitalcollections/model/impl/identifiable/resource/FileResourceImpl.java
@@ -109,6 +109,8 @@ public class FileResourceImpl extends IdentifiableImpl implements FileResource {
 
   @Override
   public String toString() {
+    String mimetypeStr = getMimeType() == null ? null : getMimeType().getTypeName();
+
     return this.getClass().getSimpleName()
         + ":"
         + "\n{"
@@ -117,7 +119,7 @@ public class FileResourceImpl extends IdentifiableImpl implements FileResource {
         + ",\n  uri="
         + String.valueOf(uri)
         + ",\n  mimetype="
-        + getMimeType().getTypeName()
+        + mimetypeStr
         + ",\n  lastModified="
         + lastModified
         + "\n}";

--- a/dc-model/src/test/java/de/digitalcollections/model/api/identifiable/resource/MimeTypeTest.java
+++ b/dc-model/src/test/java/de/digitalcollections/model/api/identifiable/resource/MimeTypeTest.java
@@ -33,8 +33,14 @@ public class MimeTypeTest {
   }
 
   @Test
-  public void returnsNullForUnknownMimetype() throws Exception {
+  public void returnsNullForUnknownMimetype1() throws Exception {
     assertThat(MimeType.fromTypename("foo/bar")).isNull();
+  }
+
+  @Test
+  public void returnsNullForUnknownMimetype2() throws Exception {
+    // GIMP image format
+    assertThat(MimeType.fromExtension("xcf")).isNull();
   }
 
   @Test

--- a/dc-model/src/test/java/de/digitalcollections/model/api/identifiable/resource/MimeTypeTest.java
+++ b/dc-model/src/test/java/de/digitalcollections/model/api/identifiable/resource/MimeTypeTest.java
@@ -1,9 +1,9 @@
 package de.digitalcollections.model.api.identifiable.resource;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import java.net.URI;
 import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class MimeTypeTest {
 
@@ -39,8 +39,7 @@ public class MimeTypeTest {
 
   @Test
   public void returnsNullForUnknownMimetype2() throws Exception {
-    // GIMP image format
-    assertThat(MimeType.fromExtension("xcf")).isNull();
+    assertThat(MimeType.fromExtension("xcfxy")).isNull();
   }
 
   @Test


### PR DESCRIPTION
to string method throws NPE if mimetype is null. made it NPE safe