### PR TITLE
Remove Guava as production dependency

### DIFF
--- a/dc-model-jackson/pom.xml
+++ b/dc-model-jackson/pom.xml
@@ -24,6 +24,12 @@
 
   <dependencies>
     <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>${version.guava}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-annotations</artifactId>
       <version>${version.jackson}</version>

--- a/dc-model-xml/pom.xml
+++ b/dc-model-xml/pom.xml
@@ -24,6 +24,12 @@
 
   <dependencies>
     <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>${version.guava}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>com.thoughtworks.xstream</groupId>
       <artifactId>xstream</artifactId>
       <version>${version.xstream}</version>

--- a/dc-model/pom.xml
+++ b/dc-model/pom.xml
@@ -2,6 +2,18 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
   <modelVersion>4.0.0</modelVersion>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <source>11</source>
+          <target>11</target>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 
   <parent>
     <groupId>de.digitalcollections.model</groupId>
@@ -15,17 +27,11 @@
 
   <properties>
     <version.commons-io>2.6</version.commons-io>
-    <version.guava>28.1-jre</version.guava>
     <version.spring-security-core>5.2.1.RELEASE</version.spring-security-core>
     <version.validation-api>2.0.1.Final</version.validation-api>
   </properties>
 
   <dependencies>
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <version>${version.guava}</version>
-    </dependency>
     <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>

--- a/dc-model/pom.xml
+++ b/dc-model/pom.xml
@@ -2,18 +2,6 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
   <modelVersion>4.0.0</modelVersion>
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <configuration>
-          <source>11</source>
-          <target>11</target>
-        </configuration>
-      </plugin>
-    </plugins>
-  </build>
 
   <parent>
     <groupId>de.digitalcollections.model</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -63,6 +63,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding> <!-- default configuration property name used by maven compiler plugin -->
 
     <version.assertj>3.14.0</version.assertj>
+    <version.guava>28.2-jre</version.guava>
     <version.junit>5.5.2</version.junit>
 
     <!-- Plugin versions -->


### PR DESCRIPTION
Heavyweight dependencies such as Guava should only be used in libraries
when really necessary. In this case the Java 11 stream API can be used
as complete replacement.

Fixes #101 (Dependabot Guava upgrade).