### PR TITLE
Replace LinkedHashSet with List

### DIFF
--- a/dc-model-jackson/pom.xml
+++ b/dc-model-jackson/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>de.digitalcollections.model</groupId>
     <artifactId>dc-model-parent</artifactId>
-    <version>5.0.0-SNAPSHOT</version>
+    <version>6.0.0-SNAPSHOT</version>
   </parent>
 
   <name>DigitalCollections: Model (Jackson)</name>

--- a/dc-model-xml/pom.xml
+++ b/dc-model-xml/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>de.digitalcollections.model</groupId>
     <artifactId>dc-model-parent</artifactId>
-    <version>5.0.0-SNAPSHOT</version>
+    <version>6.0.0-SNAPSHOT</version>
   </parent>
 
   <name>DigitalCollections: Model (XML)</name>

--- a/dc-model/pom.xml
+++ b/dc-model/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>de.digitalcollections.model</groupId>
     <artifactId>dc-model-parent</artifactId>
-    <version>5.0.0-SNAPSHOT</version>
+    <version>6.0.0-SNAPSHOT</version>
   </parent>
 
   <name>DigitalCollections: Model (Model)</name>

--- a/dc-model/src/main/java/de/digitalcollections/model/api/identifiable/Identifiable.java
+++ b/dc-model/src/main/java/de/digitalcollections/model/api/identifiable/Identifiable.java
@@ -4,7 +4,7 @@ import de.digitalcollections.model.api.identifiable.parts.LocalizedText;
 import de.digitalcollections.model.api.identifiable.parts.structuredcontent.LocalizedStructuredContent;
 import de.digitalcollections.model.api.identifiable.resource.ImageFileResource;
 import java.time.LocalDateTime;
-import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 
 public interface Identifiable {
@@ -19,9 +19,9 @@ public interface Identifiable {
 
   void addIdentifier(Identifier identifier);
 
-  List<Identifier> getIdentifiers();
+  Set<Identifier> getIdentifiers();
 
-  void setIdentifiers(List<Identifier> identifiers);
+  void setIdentifiers(Set<Identifier> identifiers);
 
   Identifier getIdentifierByNamespace(String namespace);
 

--- a/dc-model/src/main/java/de/digitalcollections/model/api/identifiable/entity/DigitalObject.java
+++ b/dc-model/src/main/java/de/digitalcollections/model/api/identifiable/entity/DigitalObject.java
@@ -3,7 +3,7 @@ package de.digitalcollections.model.api.identifiable.entity;
 import de.digitalcollections.model.api.identifiable.Version;
 import de.digitalcollections.model.api.identifiable.resource.FileResource;
 import de.digitalcollections.model.api.legal.License;
-import java.util.LinkedHashSet;
+import java.util.List;
 
 /**
  * A (cultural) digital object, can be a retro digitization of a physical object or a digital native
@@ -11,11 +11,11 @@ import java.util.LinkedHashSet;
  */
 public interface DigitalObject extends Entity {
 
-  LinkedHashSet<FileResource> getFileResources();
+  List<FileResource> getFileResources();
 
-  void setFileResources(LinkedHashSet<FileResource> fileResources);
+  void setFileResources(List<FileResource> fileResources);
 
-  LinkedHashSet<FileResource> addFileResource(FileResource fileResource);
+  void addFileResource(FileResource fileResource);
 
   License getLicense();
 

--- a/dc-model/src/main/java/de/digitalcollections/model/api/identifiable/entity/parts/ContentNode.java
+++ b/dc-model/src/main/java/de/digitalcollections/model/api/identifiable/entity/parts/ContentNode.java
@@ -3,29 +3,30 @@ package de.digitalcollections.model.api.identifiable.entity.parts;
 import de.digitalcollections.model.api.identifiable.Node;
 import de.digitalcollections.model.api.identifiable.entity.Entity;
 import de.digitalcollections.model.api.identifiable.resource.FileResource;
-import java.util.LinkedHashSet;
+import java.util.ArrayList;
+import java.util.List;
 
 public interface ContentNode<N extends Node> extends Node<N>, EntityPart {
 
-  LinkedHashSet<Entity> getEntities();
+  List<Entity> getEntities();
 
-  void setEntities(LinkedHashSet<Entity> entities);
+  void setEntities(List<Entity> entities);
 
-  default LinkedHashSet<Entity> addEntity(Entity entity) {
+  default List<Entity> addEntity(Entity entity) {
     if (getEntities() == null) {
-      setEntities(new LinkedHashSet<>());
+      setEntities(new ArrayList<>());
     }
     getEntities().add(entity);
     return getEntities();
   }
 
-  LinkedHashSet<FileResource> getFileResources();
+  List<FileResource> getFileResources();
 
-  void setFileResources(LinkedHashSet<FileResource> fileResources);
+  void setFileResources(List<FileResource> fileResources);
 
-  default LinkedHashSet<FileResource> addFileResource(FileResource fileResource) {
+  default List<FileResource> addFileResource(FileResource fileResource) {
     if (getFileResources() == null) {
-      setFileResources(new LinkedHashSet<>());
+      setFileResources(new ArrayList<>());
     }
     getFileResources().add(fileResource);
     return getFileResources();

--- a/dc-model/src/main/java/de/digitalcollections/model/impl/identifiable/IdentifiableImpl.java
+++ b/dc-model/src/main/java/de/digitalcollections/model/impl/identifiable/IdentifiableImpl.java
@@ -7,16 +7,16 @@ import de.digitalcollections.model.api.identifiable.parts.LocalizedText;
 import de.digitalcollections.model.api.identifiable.parts.structuredcontent.LocalizedStructuredContent;
 import de.digitalcollections.model.api.identifiable.resource.ImageFileResource;
 import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.LinkedList;
-import java.util.List;
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Set;
 import java.util.UUID;
 
 public class IdentifiableImpl implements Identifiable {
 
   protected LocalDateTime created;
   protected LocalizedStructuredContent description;
-  private List<Identifier> identifiers = new LinkedList<>();
+  private Set<Identifier> identifiers = new HashSet<>();
   protected LocalizedText label;
   protected LocalDateTime lastModified;
   protected ImageFileResource previewImage;
@@ -45,10 +45,7 @@ public class IdentifiableImpl implements Identifiable {
 
   @Override
   public void addIdentifier(Identifier identifier) {
-    if (identifiers == null) {
-      identifiers = new ArrayList<>();
-    }
-    identifiers.add(identifier);
+    identifiers.add(Objects.requireNonNull(identifier));
   }
 
   @Override
@@ -65,12 +62,12 @@ public class IdentifiableImpl implements Identifiable {
   }
 
   @Override
-  public List<Identifier> getIdentifiers() {
+  public Set<Identifier> getIdentifiers() {
     return identifiers;
   }
 
   @Override
-  public void setIdentifiers(List<Identifier> identifiers) {
+  public void setIdentifiers(Set<Identifier> identifiers) {
     this.identifiers = identifiers;
   }
 

--- a/dc-model/src/main/java/de/digitalcollections/model/impl/identifiable/IdentifierImpl.java
+++ b/dc-model/src/main/java/de/digitalcollections/model/impl/identifiable/IdentifierImpl.java
@@ -2,6 +2,7 @@ package de.digitalcollections.model.impl.identifiable;
 
 import de.digitalcollections.model.api.identifiable.Identifier;
 import java.io.Serializable;
+import java.util.Objects;
 import java.util.UUID;
 
 public class IdentifierImpl implements Identifier, Serializable {
@@ -49,10 +50,12 @@ public class IdentifierImpl implements Identifier, Serializable {
     this.namespace = namespace;
   }
 
+  @Override
   public UUID getUuid() {
     return uuid;
   }
 
+  @Override
   public void setUuid(UUID uuid) {
     this.uuid = uuid;
   }
@@ -60,5 +63,22 @@ public class IdentifierImpl implements Identifier, Serializable {
   @Override
   public String toString() {
     return namespace + ":" + id + ":" + identifiable;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(id, namespace);
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj) {
+      return true;
+    }
+    if (obj instanceof IdentifierImpl) {
+      final IdentifierImpl other = (IdentifierImpl) obj;
+      return Objects.equals(this.id, other.id) && Objects.equals(this.namespace, other.namespace);
+    }
+    return false;
   }
 }

--- a/dc-model/src/main/java/de/digitalcollections/model/impl/identifiable/entity/DigitalObjectImpl.java
+++ b/dc-model/src/main/java/de/digitalcollections/model/impl/identifiable/entity/DigitalObjectImpl.java
@@ -5,11 +5,12 @@ import de.digitalcollections.model.api.identifiable.entity.DigitalObject;
 import de.digitalcollections.model.api.identifiable.entity.enums.EntityType;
 import de.digitalcollections.model.api.identifiable.resource.FileResource;
 import de.digitalcollections.model.api.legal.License;
-import java.util.LinkedHashSet;
+import java.util.ArrayList;
+import java.util.List;
 
 public class DigitalObjectImpl extends EntityImpl implements DigitalObject {
 
-  private LinkedHashSet<FileResource> fileResources = new LinkedHashSet<>();
+  private List<FileResource> fileResources = new ArrayList<>();
   private License license;
   private Version version;
 
@@ -19,9 +20,8 @@ public class DigitalObjectImpl extends EntityImpl implements DigitalObject {
   }
 
   @Override
-  public LinkedHashSet<FileResource> addFileResource(FileResource fileResource) {
+  public void addFileResource(FileResource fileResource) {
     fileResources.add(fileResource);
-    return fileResources;
   }
 
   @Override
@@ -45,12 +45,12 @@ public class DigitalObjectImpl extends EntityImpl implements DigitalObject {
   }
 
   @Override
-  public LinkedHashSet<FileResource> getFileResources() {
+  public List<FileResource> getFileResources() {
     return fileResources;
   }
 
   @Override
-  public void setFileResources(LinkedHashSet<FileResource> fileResources) {
+  public void setFileResources(List<FileResource> fileResources) {
     this.fileResources = fileResources;
   }
 }

--- a/dc-model/src/main/java/de/digitalcollections/model/impl/identifiable/entity/parts/ContentNodeImpl.java
+++ b/dc-model/src/main/java/de/digitalcollections/model/impl/identifiable/entity/parts/ContentNodeImpl.java
@@ -5,14 +5,13 @@ import de.digitalcollections.model.api.identifiable.entity.parts.ContentNode;
 import de.digitalcollections.model.api.identifiable.entity.parts.enums.EntityPartType;
 import de.digitalcollections.model.api.identifiable.resource.FileResource;
 import de.digitalcollections.model.impl.identifiable.NodeImpl;
-import java.util.LinkedHashSet;
 import java.util.List;
 
 public class ContentNodeImpl extends EntityPartImpl implements ContentNode<ContentNode> {
 
   private final NodeImpl<ContentNode> node;
-  private LinkedHashSet<Entity> entites;
-  private LinkedHashSet<FileResource> fileResources;
+  private List<Entity> entites;
+  private List<FileResource> fileResources;
 
   public ContentNodeImpl() {
     super();
@@ -41,22 +40,22 @@ public class ContentNodeImpl extends EntityPartImpl implements ContentNode<Conte
   }
 
   @Override
-  public LinkedHashSet<Entity> getEntities() {
+  public List<Entity> getEntities() {
     return entites;
   }
 
   @Override
-  public void setEntities(LinkedHashSet<Entity> entities) {
+  public void setEntities(List<Entity> entities) {
     this.entites = entities;
   }
 
   @Override
-  public LinkedHashSet<FileResource> getFileResources() {
+  public List<FileResource> getFileResources() {
     return fileResources;
   }
 
   @Override
-  public void setFileResources(LinkedHashSet<FileResource> fileResources) {
+  public void setFileResources(List<FileResource> fileResources) {
     this.fileResources = fileResources;
   }
 }

--- a/dc-model/src/main/java/de/digitalcollections/model/impl/identifiable/resource/FileResourceImpl.java
+++ b/dc-model/src/main/java/de/digitalcollections/model/impl/identifiable/resource/FileResourceImpl.java
@@ -8,6 +8,7 @@ import de.digitalcollections.model.api.legal.License;
 import de.digitalcollections.model.impl.identifiable.IdentifiableImpl;
 import java.net.MalformedURLException;
 import java.net.URI;
+import java.util.Objects;
 
 public class FileResourceImpl extends IdentifiableImpl implements FileResource {
 
@@ -136,5 +137,26 @@ public class FileResourceImpl extends IdentifiableImpl implements FileResource {
         + ",\n  lastModified="
         + lastModified
         + "\n}";
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(filename, fileResourceType, mimeType, sizeInBytes, uri);
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj) {
+      return true;
+    }
+    if (obj instanceof FileResourceImpl) {
+      final FileResourceImpl other = (FileResourceImpl) obj;
+      return Objects.equals(this.filename, other.filename)
+          && Objects.equals(this.fileResourceType, other.fileResourceType)
+          && Objects.equals(this.mimeType, other.mimeType)
+          && Objects.equals(this.sizeInBytes, other.sizeInBytes)
+          && Objects.equals(this.uri, other.uri);
+    }
+    return false;
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>de.digitalcollections.model</groupId>
   <artifactId>dc-model-parent</artifactId>
-  <version>5.0.0-SNAPSHOT</version>
+  <version>6.0.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <modules>


### PR DESCRIPTION
- Replace LinkedHashSet with List for ordered lists
- Replace List with Set for unordered Lists without duplicates
- add hashCode and equals where needed
- Bump version to 6.0.0-SNAPSHOT as it is a API/breaking change
- fixes #44 