### PR TITLE
Add generic fileresource type (undefined)

### DIFF
--- a/dc-model-jackson/src/main/java/de/digitalcollections/model/jackson/mixin/identifiable/resource/FileResourceMixIn.java
+++ b/dc-model-jackson/src/main/java/de/digitalcollections/model/jackson/mixin/identifiable/resource/FileResourceMixIn.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import de.digitalcollections.model.impl.identifiable.resource.ApplicationFileResourceImpl;
 import de.digitalcollections.model.impl.identifiable.resource.AudioFileResourceImpl;
+import de.digitalcollections.model.impl.identifiable.resource.FileResourceImpl;
 import de.digitalcollections.model.impl.identifiable.resource.ImageFileResourceImpl;
 import de.digitalcollections.model.impl.identifiable.resource.LinkedDataFileResourceImpl;
 import de.digitalcollections.model.impl.identifiable.resource.TextFileResourceImpl;
@@ -19,6 +20,7 @@ import de.digitalcollections.model.impl.identifiable.resource.VideoFileResourceI
 @JsonSubTypes({
   @JsonSubTypes.Type(value = ApplicationFileResourceImpl.class, name = "APPLICATION"),
   @JsonSubTypes.Type(value = AudioFileResourceImpl.class, name = "AUDIO"),
+  @JsonSubTypes.Type(value = FileResourceImpl.class, name = "UNDEFINED"),
   @JsonSubTypes.Type(value = ImageFileResourceImpl.class, name = "IMAGE"),
   @JsonSubTypes.Type(value = LinkedDataFileResourceImpl.class, name = "LINKED_DATA"),
   @JsonSubTypes.Type(value = TextFileResourceImpl.class, name = "TEXT"),

--- a/dc-model/src/main/java/de/digitalcollections/model/api/identifiable/resource/enums/FileResourceType.java
+++ b/dc-model/src/main/java/de/digitalcollections/model/api/identifiable/resource/enums/FileResourceType.java
@@ -6,6 +6,7 @@ public enum FileResourceType {
   IMAGE,
   LINKED_DATA,
   TEXT,
+  UNDEFINED,
   VIDEO;
 
   @Override

--- a/dc-model/src/main/java/de/digitalcollections/model/impl/identifiable/resource/FileResourceImpl.java
+++ b/dc-model/src/main/java/de/digitalcollections/model/impl/identifiable/resource/FileResourceImpl.java
@@ -24,6 +24,7 @@ public class FileResourceImpl extends IdentifiableImpl implements FileResource {
   public FileResourceImpl() {
     super();
     this.type = IdentifiableType.RESOURCE;
+    this.fileResourceType = FileResourceType.UNDEFINED;
   }
 
   @Override


### PR DESCRIPTION
For list of all fileresources every file resource is just filled with needed core properties of fileresource, no fileresource specific fields are filled. This merge request makes it possible to get such a generic list (with serializing and deserializing)