### PR TITLE
Fix erroneous extension for mimetypes without given extensions

### DIFF
--- a/dc-model/src/main/java/de/digitalcollections/model/api/identifiable/resource/MimeType.java
+++ b/dc-model/src/main/java/de/digitalcollections/model/api/identifiable/resource/MimeType.java
@@ -51,7 +51,7 @@ public class MimeType {
           if (columns.length > 1) {
             return columns;
           }
-          return new String[] {columns[0], columns[0]};
+          return new String[] {columns[0], ""};
         };
 
     knownTypes =
@@ -66,7 +66,12 @@ public class MimeType {
             .collect(
                 Collectors.toMap(
                     columns -> columns[0],
-                    columns -> new MimeType(columns[0], List.of(columns[1].split(" ")))));
+                    columns ->
+                        new MimeType(
+                            columns[0],
+                            "".equals(columns[1])
+                                ? Collections.<String>emptyList()
+                                : List.of(columns[1].split(" ")))));
 
     // Some custom overrides to influence the order of file extensions
     // Since these are added to the end of the list, they take precedence over the

--- a/dc-model/src/test/java/de/digitalcollections/model/api/identifiable/resource/MimeTypeTest.java
+++ b/dc-model/src/test/java/de/digitalcollections/model/api/identifiable/resource/MimeTypeTest.java
@@ -33,6 +33,17 @@ public class MimeTypeTest {
   }
 
   @Test
+  public void getMimeTypeForMimeTypeWithoutExtensions() throws Exception {
+    assertThat(MimeType.fromTypename("application/vnd.debian.binary-package").getPrimaryType())
+        .isEqualTo("application");
+    assertThat(MimeType.fromTypename("application/vnd.debian.binary-package").getSubType())
+        .isEqualTo("vnd.debian.binary-package");
+    assertThat(MimeType.fromTypename("application/vnd.debian.binary-package").getSuffix()).isNull();
+    assertThat(MimeType.fromTypename("application/vnd.debian.binary-package").getExtensions())
+        .isEmpty();
+  }
+
+  @Test
   public void returnsNullForUnknownMimetype1() throws Exception {
     assertThat(MimeType.fromTypename("foo/bar")).isNull();
   }
@@ -77,6 +88,10 @@ public class MimeTypeTest {
   public void testFromFilename() throws Exception {
     assertThat(MimeType.fromFilename("hahaha.tar.gz")).isNull();
     assertThat(MimeType.fromFilename("hahaha.zip").getTypeName()).isEqualTo("application/zip");
+    assertThat(
+            MimeType.fromFilename("libjavascriptcoregtk-1.0-0_2.4.11-3ubuntu3_amd64.deb")
+                .getTypeName())
+        .isEqualTo("application/x-debian-package");
   }
 
   @Test


### PR DESCRIPTION
Fix erroneous extension for mimetypes without given extensions. Now extensions are empty if no extension is in dc.mime.types