### PR TITLE
Add rendering hints object for preview image of an identifiable

### DIFF
--- a/dc-model-jackson/src/main/java/de/digitalcollections/model/jackson/DigitalCollectionsModelModule.java
+++ b/dc-model-jackson/src/main/java/de/digitalcollections/model/jackson/DigitalCollectionsModelModule.java
@@ -23,6 +23,7 @@ import de.digitalcollections.model.api.identifiable.entity.Website;
 import de.digitalcollections.model.api.identifiable.entity.parts.Subtopic;
 import de.digitalcollections.model.api.identifiable.entity.parts.Webpage;
 import de.digitalcollections.model.api.identifiable.parts.LocalizedText;
+import de.digitalcollections.model.api.identifiable.parts.RenderingHintsPreviewImage;
 import de.digitalcollections.model.api.identifiable.parts.Translation;
 import de.digitalcollections.model.api.identifiable.parts.structuredcontent.ContentBlock;
 import de.digitalcollections.model.api.identifiable.parts.structuredcontent.LocalizedStructuredContent;
@@ -97,6 +98,7 @@ import de.digitalcollections.model.jackson.mixin.identifiable.resource.AudioFile
 import de.digitalcollections.model.jackson.mixin.identifiable.resource.FileResourceMixIn;
 import de.digitalcollections.model.jackson.mixin.identifiable.resource.ImageFileResourceMixIn;
 import de.digitalcollections.model.jackson.mixin.identifiable.resource.LinkedDataFileResourceMixIn;
+import de.digitalcollections.model.jackson.mixin.identifiable.resource.RenderingHintsPreviewImageMixIn;
 import de.digitalcollections.model.jackson.mixin.identifiable.resource.TextFileResourceMixIn;
 import de.digitalcollections.model.jackson.mixin.identifiable.resource.VideoFileResourceMixIn;
 import de.digitalcollections.model.jackson.mixin.legal.LicenseMixIn;
@@ -177,6 +179,8 @@ public class DigitalCollectionsModelModule extends SimpleModule {
     context.setMixInAnnotations(PageResponse.class, PageResponseMixIn.class);
     context.setMixInAnnotations(Paragraph.class, ParagraphMixIn.class);
     context.setMixInAnnotations(Project.class, ProjectMixIn.class);
+    context.setMixInAnnotations(
+        RenderingHintsPreviewImage.class, RenderingHintsPreviewImageMixIn.class);
     context.setMixInAnnotations(Sorting.class, SortingMixIn.class);
     context.setMixInAnnotations(StructuredContent.class, StructuredContentMixIn.class);
     context.setMixInAnnotations(Subtopic.class, SubtopicMixIn.class);

--- a/dc-model-jackson/src/main/java/de/digitalcollections/model/jackson/mixin/identifiable/resource/RenderingHintsPreviewImageMixIn.java
+++ b/dc-model-jackson/src/main/java/de/digitalcollections/model/jackson/mixin/identifiable/resource/RenderingHintsPreviewImageMixIn.java
@@ -1,0 +1,9 @@
+package de.digitalcollections.model.jackson.mixin.identifiable.resource;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import de.digitalcollections.model.impl.identifiable.parts.RenderingHintsPreviewImageImpl;
+
+@JsonDeserialize(as = RenderingHintsPreviewImageImpl.class)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public interface RenderingHintsPreviewImageMixIn {}

--- a/dc-model-jackson/src/test/java/de/digitalcollections/model/jackson/identifiable/resource/RenderingHintsImageTest.java
+++ b/dc-model-jackson/src/test/java/de/digitalcollections/model/jackson/identifiable/resource/RenderingHintsImageTest.java
@@ -1,0 +1,25 @@
+package de.digitalcollections.model.jackson.identifiable.resource;
+
+import de.digitalcollections.model.impl.identifiable.parts.LocalizedTextImpl;
+import de.digitalcollections.model.impl.identifiable.parts.RenderingHintsPreviewImageImpl;
+import de.digitalcollections.model.jackson.BaseJsonSerializationTest;
+import java.net.URI;
+import java.util.Locale;
+import org.junit.jupiter.api.Test;
+
+public class RenderingHintsImageTest extends BaseJsonSerializationTest {
+
+  @Test
+  public void testSerialisationInBothWays() throws Exception {
+    RenderingHintsPreviewImageImpl hints = new RenderingHintsPreviewImageImpl();
+    hints.setAltText(new LocalizedTextImpl(Locale.ENGLISH, "image001.jpg"));
+    hints.setCaption(
+        new LocalizedTextImpl(Locale.ENGLISH, "Wonderful landscape in Lower Bavaria, Germany."));
+    hints.setTitle(new LocalizedTextImpl(Locale.ENGLISH, "Photo of city of Straubing"));
+    hints.setOpenLinkInNewWindow(true);
+    hints.setTargetLink(
+        URI.create("https://upload.wikimedia.org/wikipedia/commons/1/11/Straubinger_Stadtbild.jpg")
+            .toURL());
+    checkSerializeDeserialize(hints);
+  }
+}

--- a/dc-model/src/main/java/de/digitalcollections/model/api/identifiable/Identifiable.java
+++ b/dc-model/src/main/java/de/digitalcollections/model/api/identifiable/Identifiable.java
@@ -1,12 +1,25 @@
 package de.digitalcollections.model.api.identifiable;
 
 import de.digitalcollections.model.api.identifiable.parts.LocalizedText;
+import de.digitalcollections.model.api.identifiable.parts.RenderingHintsPreviewImage;
 import de.digitalcollections.model.api.identifiable.parts.structuredcontent.LocalizedStructuredContent;
 import de.digitalcollections.model.api.identifiable.resource.ImageFileResource;
 import java.time.LocalDateTime;
 import java.util.Set;
 import java.util.UUID;
 
+/**
+ * An Identifiable is an uniquely identifiable {@link
+ * de.digitalcollections.model.api.identifiable.entity.Entity} or {@link
+ * de.digitalcollections.model.api.identifiable.resource.FileResource}, having one or more unique
+ * {@link Identifier}(s).<br>
+ *
+ * <ul>
+ *   <li>FileResources have one (or more) technical (system wide) Identifiers (e.g. an UUID)
+ *   <li>Entities additionally have one (or more) “domain-specific” (system independent) Identifiers
+ *       (e.g. GND-ID, VIAF-ID)
+ * </ul>
+ */
 public interface Identifiable {
 
   LocalDateTime getCreated();
@@ -36,6 +49,10 @@ public interface Identifiable {
   ImageFileResource getPreviewImage();
 
   void setPreviewImage(ImageFileResource previewImage);
+
+  RenderingHintsPreviewImage getPreviewImageRenderingHints();
+
+  void setPreviewImageRenderingHints(RenderingHintsPreviewImage previewImageRenderingHints);
 
   IdentifiableType getType();
 

--- a/dc-model/src/main/java/de/digitalcollections/model/api/identifiable/parts/RenderingHintsPreviewImage.java
+++ b/dc-model/src/main/java/de/digitalcollections/model/api/identifiable/parts/RenderingHintsPreviewImage.java
@@ -1,0 +1,76 @@
+package de.digitalcollections.model.api.identifiable.parts;
+
+import java.net.URL;
+
+/**
+ * Contains hints for rendering a preview image, e.g. in a webpage as HTML.<br>
+ * These are related to an {@link
+ * de.digitalcollections.model.api.identifiable.resource.ImageFileResource} but there may exist more
+ * than one rendering hints container, each per individual use case.<br>
+ * This makes it possible to use/embed an image in several projects and locations, each time
+ * rendered individually.<br>
+ * The rendering hints therefore are kept separate in an own rendering hints object and have to be
+ * stored in conjunction with each specific use case.
+ *
+ * <p>Example:<br>
+ * A person object has a portrait photo as preview image. On the detail page of this person (= use
+ * case) specific caption and link are defined.<br>
+ * So at the person storage an {@link
+ * de.digitalcollections.model.api.identifiable.resource.ImageFileResource} is defined as preview
+ * image and individual filled rendering hints are stored beside at the person object (and not
+ * "centrally" at the reusable {@link
+ * de.digitalcollections.model.api.identifiable.resource.ImageFileResource}).
+ *
+ * <p>This makes it possible to reuse an image in different use cases but with individual alt-text,
+ * caption, (mouseover) title and link.
+ */
+public interface RenderingHintsPreviewImage {
+
+  /**
+   * @return localized text that is shown as alternative if image can not be shown and for
+   *     accessibility (e.g. screen-reader)
+   */
+  LocalizedText getAltText();
+
+  /**
+   * @param altText localized text that is shown as alternative if image can not be shown and for
+   *     accessibility (e.g. screen-reader)
+   */
+  void setAltText(LocalizedText altText);
+
+  /** @return localized text that may be shown e.g. as "subtitle" under an image */
+  LocalizedText getCaption();
+
+  /** @param caption localized text that may be shown e.g. as "subtitle" under an image */
+  void setCaption(LocalizedText caption);
+
+  /**
+   * @return localized text that may be shown e.g. as "mouseover" if image is rendered in an HTML
+   *     page
+   */
+  LocalizedText getTitle();
+
+  /**
+   * @param title localized text that may be shown e.g. as "mouseover" if image is rendered in an
+   *     HTML page
+   */
+  void setTitle(LocalizedText title);
+
+  /**
+   * @return url that is linked with the image and/or caption, e.g. used for click on image/caption
+   *     as target location
+   */
+  URL getTargetLink();
+
+  /**
+   * @param targetLink url that is linked with the image and/or caption, e.g. used for click on
+   *     image/caption as target location
+   */
+  void setTargetLink(URL targetLink);
+
+  /** @return if targetLink should be opened in new window */
+  boolean isOpenLinkInNewWindow();
+
+  /** @param openLinkInNewWindow "true" if targetLink should be opened in new window */
+  void setOpenLinkInNewWindow(boolean openLinkInNewWindow);
+}

--- a/dc-model/src/main/java/de/digitalcollections/model/impl/identifiable/IdentifiableImpl.java
+++ b/dc-model/src/main/java/de/digitalcollections/model/impl/identifiable/IdentifiableImpl.java
@@ -4,6 +4,7 @@ import de.digitalcollections.model.api.identifiable.Identifiable;
 import de.digitalcollections.model.api.identifiable.IdentifiableType;
 import de.digitalcollections.model.api.identifiable.Identifier;
 import de.digitalcollections.model.api.identifiable.parts.LocalizedText;
+import de.digitalcollections.model.api.identifiable.parts.RenderingHintsPreviewImage;
 import de.digitalcollections.model.api.identifiable.parts.structuredcontent.LocalizedStructuredContent;
 import de.digitalcollections.model.api.identifiable.resource.ImageFileResource;
 import java.time.LocalDateTime;
@@ -20,6 +21,7 @@ public class IdentifiableImpl implements Identifiable {
   protected LocalizedText label;
   protected LocalDateTime lastModified;
   protected ImageFileResource previewImage;
+  protected RenderingHintsPreviewImage previewImageRenderingHints;
   protected IdentifiableType type;
   private UUID uuid;
 
@@ -119,5 +121,15 @@ public class IdentifiableImpl implements Identifiable {
   @Override
   public void setUuid(UUID uuid) {
     this.uuid = uuid;
+  }
+
+  @Override
+  public RenderingHintsPreviewImage getPreviewImageRenderingHints() {
+    return previewImageRenderingHints;
+  }
+
+  @Override
+  public void setPreviewImageRenderingHints(RenderingHintsPreviewImage previewImageRenderingHints) {
+    this.previewImageRenderingHints = previewImageRenderingHints;
   }
 }

--- a/dc-model/src/main/java/de/digitalcollections/model/impl/identifiable/parts/RenderingHintsPreviewImageImpl.java
+++ b/dc-model/src/main/java/de/digitalcollections/model/impl/identifiable/parts/RenderingHintsPreviewImageImpl.java
@@ -1,0 +1,64 @@
+package de.digitalcollections.model.impl.identifiable.parts;
+
+import de.digitalcollections.model.api.identifiable.parts.LocalizedText;
+import de.digitalcollections.model.api.identifiable.parts.RenderingHintsPreviewImage;
+import java.net.URL;
+
+public class RenderingHintsPreviewImageImpl implements RenderingHintsPreviewImage {
+
+  private LocalizedText altText;
+  private LocalizedText caption;
+  private LocalizedText title;
+  private URL targetLink;
+  private boolean openLinkInNewWindow;
+
+  @Override
+  public LocalizedText getAltText() {
+    return altText;
+  }
+
+  @Override
+  public void setAltText(LocalizedText altText) {
+    this.altText = altText;
+  }
+
+  @Override
+  public LocalizedText getCaption() {
+    return caption;
+  }
+
+  @Override
+  public void setCaption(LocalizedText caption) {
+    this.caption = caption;
+  }
+
+  @Override
+  public LocalizedText getTitle() {
+    return title;
+  }
+
+  @Override
+  public void setTitle(LocalizedText title) {
+    this.title = title;
+  }
+
+  @Override
+  public URL getTargetLink() {
+    return targetLink;
+  }
+
+  @Override
+  public void setTargetLink(URL targetLink) {
+    this.targetLink = targetLink;
+  }
+
+  @Override
+  public void setOpenLinkInNewWindow(boolean openLinkInNewWindow) {
+    this.openLinkInNewWindow = openLinkInNewWindow;
+  }
+
+  @Override
+  public boolean isOpenLinkInNewWindow() {
+    return openLinkInNewWindow;
+  }
+}


### PR DESCRIPTION
For rendering a preview image (e.g. use case: news with image) it is necessary to add some rendering information to the preview image supporting accessibility rules (alt, title) and optional caption and target link (in new window or same). This has to be stored separate from image that can be used in different places with different rendering hints.

This pull request adds an object containing rendering hints and adds it beside preview image to every identifiable (already having preview image)