### PR TITLE
Add FilterValuePlaceholder

### DIFF
--- a/dc-model/src/main/java/de/digitalcollections/model/api/filter/FilterValuePlaceholder.java
+++ b/dc-model/src/main/java/de/digitalcollections/model/api/filter/FilterValuePlaceholder.java
@@ -1,0 +1,17 @@
+package de.digitalcollections.model.api.filter;
+
+/** Use this class for uninterpreted filter values. Given String should be used "as is". */
+public class FilterValuePlaceholder {
+
+  private final String placeholder;
+
+  /** @param placeholder uninterpreted filter value */
+  public FilterValuePlaceholder(String placeholder) {
+    this.placeholder = placeholder;
+  }
+
+  @Override
+  public String toString() {
+    return placeholder;
+  }
+}


### PR DESCRIPTION
New class for handling filter values that should not be parsed (e.g: use ":uuid" as is and do not wrap single quotes around it in sql)