### PR TITLE
Serialization fixes

### DIFF
--- a/dc-model-jackson/src/main/java/de/digitalcollections/model/jackson/mixin/paging/PageResponseMixIn.java
+++ b/dc-model-jackson/src/main/java/de/digitalcollections/model/jackson/mixin/paging/PageResponseMixIn.java
@@ -37,7 +37,7 @@ import java.util.List;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public abstract class PageResponseMixIn<T> extends PageResponse<T> {
 
-  @JsonTypeInfo(use = Id.NAME, property = "contenttype", visible = true)
+  @JsonTypeInfo(use = Id.NAME, property = "objecttype", visible = true)
   @JsonSubTypes({
     @Type(value = Article.class, name = "ARTICLE"),
     @Type(value = Collection.class, name = "COLLECTION"),

--- a/dc-model-jackson/src/main/java/de/digitalcollections/model/jackson/mixin/paging/PageResponseMixIn.java
+++ b/dc-model-jackson/src/main/java/de/digitalcollections/model/jackson/mixin/paging/PageResponseMixIn.java
@@ -37,7 +37,7 @@ import java.util.List;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public abstract class PageResponseMixIn<T> extends PageResponse<T> {
 
-  @JsonTypeInfo(use = Id.NAME, property = "objecttype", visible = true)
+  @JsonTypeInfo(use = Id.NAME, property = "objectType", visible = true)
   @JsonSubTypes({
     @Type(value = Article.class, name = "ARTICLE"),
     @Type(value = Collection.class, name = "COLLECTION"),

--- a/dc-model-jackson/src/main/java/de/digitalcollections/model/jackson/mixin/paging/PageResponseMixIn.java
+++ b/dc-model-jackson/src/main/java/de/digitalcollections/model/jackson/mixin/paging/PageResponseMixIn.java
@@ -2,21 +2,66 @@ package de.digitalcollections.model.jackson.mixin.paging;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonSubTypes.Type;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import de.digitalcollections.model.identifiable.Identifiable;
+import de.digitalcollections.model.identifiable.IdentifierType;
+import de.digitalcollections.model.identifiable.agent.FamilyName;
+import de.digitalcollections.model.identifiable.agent.GivenName;
+import de.digitalcollections.model.identifiable.entity.Article;
+import de.digitalcollections.model.identifiable.entity.Collection;
+import de.digitalcollections.model.identifiable.entity.DigitalObject;
+import de.digitalcollections.model.identifiable.entity.Entity;
+import de.digitalcollections.model.identifiable.entity.Project;
+import de.digitalcollections.model.identifiable.entity.Topic;
+import de.digitalcollections.model.identifiable.entity.Website;
+import de.digitalcollections.model.identifiable.entity.agent.CorporateBody;
+import de.digitalcollections.model.identifiable.entity.agent.Person;
+import de.digitalcollections.model.identifiable.entity.geo.location.GeoLocation;
+import de.digitalcollections.model.identifiable.entity.geo.location.HumanSettlement;
+import de.digitalcollections.model.identifiable.entity.relation.EntityRelation;
+import de.digitalcollections.model.identifiable.entity.work.Item;
+import de.digitalcollections.model.identifiable.entity.work.Work;
+import de.digitalcollections.model.identifiable.resource.FileResource;
+import de.digitalcollections.model.identifiable.web.Webpage;
 import de.digitalcollections.model.paging.PageResponse;
 import de.digitalcollections.model.paging.Sorting;
+import de.digitalcollections.model.security.User;
+import de.digitalcollections.model.view.RenderingTemplate;
 import java.util.List;
 
 @JsonDeserialize(as = PageResponse.class)
 @JsonIgnoreProperties(ignoreUnknown = true)
 public abstract class PageResponseMixIn<T> extends PageResponse<T> {
 
-  @JsonTypeInfo(
-      use = JsonTypeInfo.Id.CLASS,
-      include = JsonTypeInfo.As.PROPERTY,
-      property = "className",
-      visible = true)
+  @JsonTypeInfo(use = Id.NAME, property = "contenttype", visible = true)
+  @JsonSubTypes({
+    @Type(value = Article.class, name = "ARTICLE"),
+    @Type(value = Collection.class, name = "COLLECTION"),
+    @Type(value = CorporateBody.class, name = "CORPORATE_BODY"),
+    @Type(value = DigitalObject.class, name = "DIGITAL_OBJECT"),
+    @Type(value = Entity.class, name = "ENTITY"),
+    @Type(value = EntityRelation.class, name = "ENTITY_RELATION"),
+    @Type(value = FamilyName.class, name = "FAMILY_NAME"),
+    @Type(value = FileResource.class, name = "FILE_RESOURCE"),
+    @Type(value = GeoLocation.class, name = "GEO_LOCATION"),
+    @Type(value = GivenName.class, name = "GIVEN_NAME"),
+    @Type(value = HumanSettlement.class, name = "HUMAN_SETTLEMENT"),
+    @Type(value = Identifiable.class, name = "IDENTIFIABLE"),
+    @Type(value = IdentifierType.class, name = "IDENTIFIER_TYPE"),
+    @Type(value = Item.class, name = "ITEM"),
+    @Type(value = Person.class, name = "PERSON"),
+    @Type(value = Project.class, name = "PROJECT"),
+    @Type(value = RenderingTemplate.class, name = "RENDERING_TEMPLATE"),
+    @Type(value = Topic.class, name = "TOPIC"),
+    @Type(value = User.class, name = "USER"),
+    @Type(value = Webpage.class, name = "WEBPAGE"),
+    @Type(value = Website.class, name = "WEBSITE"),
+    @Type(value = Work.class, name = "WORK")
+  })
   @Override
   public abstract List<T> getContent();
 

--- a/dc-model-jackson/src/main/java/de/digitalcollections/model/jackson/mixin/view/BreadcrumbNavigationMixIn.java
+++ b/dc-model-jackson/src/main/java/de/digitalcollections/model/jackson/mixin/view/BreadcrumbNavigationMixIn.java
@@ -1,9 +1,11 @@
 package de.digitalcollections.model.jackson.mixin.view;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import de.digitalcollections.model.view.BreadcrumbNavigation;
 
 @JsonDeserialize(as = BreadcrumbNavigation.class)
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonTypeName("BREADCRUMB_NAVIGATION")
 public interface BreadcrumbNavigationMixIn {}

--- a/dc-model-jackson/src/main/java/de/digitalcollections/model/jackson/mixin/view/RenderingHintsMixIn.java
+++ b/dc-model-jackson/src/main/java/de/digitalcollections/model/jackson/mixin/view/RenderingHintsMixIn.java
@@ -1,9 +1,11 @@
 package de.digitalcollections.model.jackson.mixin.view;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import de.digitalcollections.model.view.RenderingHints;
 
 @JsonDeserialize(as = RenderingHints.class)
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonTypeName("RENDERING_HINTS")
 public class RenderingHintsMixIn {}

--- a/dc-model-jackson/src/main/java/de/digitalcollections/model/jackson/mixin/view/RenderingHintsPreviewImageMixIn.java
+++ b/dc-model-jackson/src/main/java/de/digitalcollections/model/jackson/mixin/view/RenderingHintsPreviewImageMixIn.java
@@ -1,9 +1,11 @@
 package de.digitalcollections.model.jackson.mixin.view;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import de.digitalcollections.model.view.RenderingHintsPreviewImage;
 
 @JsonDeserialize(as = RenderingHintsPreviewImage.class)
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonTypeName("RENDERING_HINTS_PREVIEW_IMAGE")
 public interface RenderingHintsPreviewImageMixIn {}

--- a/dc-model-jackson/src/main/java/de/digitalcollections/model/jackson/mixin/view/RenderingTemplateMixIn.java
+++ b/dc-model-jackson/src/main/java/de/digitalcollections/model/jackson/mixin/view/RenderingTemplateMixIn.java
@@ -1,9 +1,11 @@
 package de.digitalcollections.model.jackson.mixin.view;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import de.digitalcollections.model.view.RenderingTemplate;
 
 @JsonDeserialize(as = RenderingTemplate.class)
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonTypeName("RENDERING_TEMPLATE")
 public interface RenderingTemplateMixIn {}

--- a/dc-model-jackson/src/test/java/de/digitalcollections/model/jackson/BaseJsonSerializationTest.java
+++ b/dc-model-jackson/src/test/java/de/digitalcollections/model/jackson/BaseJsonSerializationTest.java
@@ -75,7 +75,6 @@ public abstract class BaseJsonSerializationTest {
     if (pathToJson != null) {
       Assertions.assertEquals(serializedObject, readFromResources(pathToJson));
     }
-    LOGGER.info("serialized object: '" + serializedObject + "'");
 
     Class valueType = o.getClass();
     T deserializedObject = (T) getMapper().readValue(serializedObject, valueType);

--- a/dc-model-jackson/src/test/java/de/digitalcollections/model/jackson/paging/SearchPageResponseTest.java
+++ b/dc-model-jackson/src/test/java/de/digitalcollections/model/jackson/paging/SearchPageResponseTest.java
@@ -1,0 +1,34 @@
+package de.digitalcollections.model.jackson.paging;
+
+import de.digitalcollections.model.identifiable.Identifiable;
+import de.digitalcollections.model.identifiable.entity.DigitalObject;
+import de.digitalcollections.model.identifiable.web.Webpage;
+import de.digitalcollections.model.jackson.BaseJsonSerializationTest;
+import de.digitalcollections.model.paging.SearchPageResponse;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("The SearchPageResponse")
+public class SearchPageResponseTest extends BaseJsonSerializationTest {
+
+  @Test
+  @DisplayName("can serialize and deserialize different types")
+  public void differentTypes() throws Exception {
+    List<Identifiable> content = new ArrayList<>();
+    DigitalObject digitalObject = new DigitalObject();
+    digitalObject.setLabel("DigitalObject-Label");
+    content.add(digitalObject);
+    Webpage webpage = new Webpage();
+    webpage.setLabel("Webpage-Label");
+    content.add(webpage);
+
+    SearchPageResponse<Identifiable> resp = new SearchPageResponse<>();
+    resp.setContent(content);
+    resp.setTotalElements(2);
+
+    checkSerializeDeserialize(resp, "serializedTestObjects/paging/SearchPageResponse.json");
+  }
+
+}

--- a/dc-model-jackson/src/test/resources/serializedTestObjects/paging/PageResponse.json
+++ b/dc-model-jackson/src/test/resources/serializedTestObjects/paging/PageResponse.json
@@ -1,6 +1,6 @@
 {
   "content" : [ {
-    "contenttype" : "USER",
+    "objecttype" : "USER",
     "email" : "test@user.de",
     "enabled" : true,
     "roles" : [ ]

--- a/dc-model-jackson/src/test/resources/serializedTestObjects/paging/PageResponse.json
+++ b/dc-model-jackson/src/test/resources/serializedTestObjects/paging/PageResponse.json
@@ -1,6 +1,6 @@
 {
   "content" : [ {
-    "objecttype" : "USER",
+    "objectType" : "USER",
     "email" : "test@user.de",
     "enabled" : true,
     "roles" : [ ]

--- a/dc-model-jackson/src/test/resources/serializedTestObjects/paging/PageResponse.json
+++ b/dc-model-jackson/src/test/resources/serializedTestObjects/paging/PageResponse.json
@@ -1,6 +1,6 @@
 {
   "content" : [ {
-    "className" : "de.digitalcollections.model.security.User",
+    "contenttype" : "USER",
     "email" : "test@user.de",
     "enabled" : true,
     "roles" : [ ]

--- a/dc-model-jackson/src/test/resources/serializedTestObjects/paging/SearchPageResponse.json
+++ b/dc-model-jackson/src/test/resources/serializedTestObjects/paging/SearchPageResponse.json
@@ -1,6 +1,6 @@
 {
   "content" : [ {
-    "contenttype" : "DIGITAL_OBJECT",
+    "objecttype" : "DIGITAL_OBJECT",
     "identifiers" : [ ],
     "label" : {
       "" : "DigitalObject-Label"
@@ -10,7 +10,7 @@
     "refId" : 0,
     "fileResources" : [ ]
   }, {
-    "contenttype" : "WEBPAGE",
+    "objecttype" : "WEBPAGE",
     "identifiers" : [ ],
     "label" : {
       "" : "Webpage-Label"

--- a/dc-model-jackson/src/test/resources/serializedTestObjects/paging/SearchPageResponse.json
+++ b/dc-model-jackson/src/test/resources/serializedTestObjects/paging/SearchPageResponse.json
@@ -1,0 +1,21 @@
+{
+  "content" : [ {
+    "contenttype" : "DIGITAL_OBJECT",
+    "identifiers" : [ ],
+    "label" : {
+      "" : "DigitalObject-Label"
+    },
+    "type" : "ENTITY",
+    "entityType" : "DIGITAL_OBJECT",
+    "refId" : 0,
+    "fileResources" : [ ]
+  }, {
+    "contenttype" : "WEBPAGE",
+    "identifiers" : [ ],
+    "label" : {
+      "" : "Webpage-Label"
+    },
+    "type" : "RESOURCE"
+  } ],
+  "totalElements" : 2
+}

--- a/dc-model-jackson/src/test/resources/serializedTestObjects/paging/SearchPageResponse.json
+++ b/dc-model-jackson/src/test/resources/serializedTestObjects/paging/SearchPageResponse.json
@@ -1,6 +1,6 @@
 {
   "content" : [ {
-    "objecttype" : "DIGITAL_OBJECT",
+    "objectType" : "DIGITAL_OBJECT",
     "identifiers" : [ ],
     "label" : {
       "" : "DigitalObject-Label"
@@ -10,7 +10,7 @@
     "refId" : 0,
     "fileResources" : [ ]
   }, {
-    "objecttype" : "WEBPAGE",
+    "objectType" : "WEBPAGE",
     "identifiers" : [ ],
     "label" : {
       "" : "Webpage-Label"


### PR DESCRIPTION
- Type info (Field `type`) also for non-resources and non-entities
- Type info (Field `objectType`) for content objects in page responses