### PR TITLE
Extend LocalizedUrlAliases model

### DIFF
--- a/dc-model-jackson/src/main/java/de/digitalcollections/model/jackson/mixin/alias/LocalizedUrlAliasesMixIn.java
+++ b/dc-model-jackson/src/main/java/de/digitalcollections/model/jackson/mixin/alias/LocalizedUrlAliasesMixIn.java
@@ -16,6 +16,12 @@ public interface LocalizedUrlAliasesMixIn {
   void add(UrlAlias... urlAlias);
 
   @JsonIgnore
+  boolean containsUrlAlias(UrlAlias urlAlias);
+
+  @JsonIgnore
+  List<UrlAlias> flatten();
+
+  @JsonIgnore
   List<Locale> getTargetLanguages();
 
   @JsonIgnore

--- a/dc-model/src/main/java/de/digitalcollections/model/alias/LocalizedUrlAliases.java
+++ b/dc-model/src/main/java/de/digitalcollections/model/alias/LocalizedUrlAliases.java
@@ -4,19 +4,28 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
+import java.util.stream.Collectors;
 
 public class LocalizedUrlAliases extends HashMap<Locale, List<UrlAlias>> {
 
-  public LocalizedUrlAliases() {
-    super();
-  }
-
+  /**
+   * Constructor, can be called without parameters as well, i.e. {@code new LocalizedUrlAliases()}
+   *
+   * @param urlAliases Not {@code null}
+   */
   public LocalizedUrlAliases(UrlAlias... urlAliases) {
-    this();
+    super();
     this.add(urlAliases);
   }
 
+  public LocalizedUrlAliases(List<UrlAlias> urlAliases) {
+    this(urlAliases.toArray(UrlAlias[]::new));
+  }
+
   public void add(UrlAlias... urlAliases) {
+    if (urlAliases == null) {
+      return;
+    }
     for (UrlAlias urlAlias : urlAliases) {
       this.compute(
           urlAlias.getTargetLanguage(),
@@ -28,6 +37,32 @@ public class LocalizedUrlAliases extends HashMap<Locale, List<UrlAlias>> {
             return listOfAliases;
           });
     }
+  }
+
+  /** Check whether the passed {@code UrlAlias} is contained in any of the locale specific lists. */
+  public boolean containsUrlAlias(UrlAlias urlAlias) {
+    return this.flatten().contains(urlAlias);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (o == this) {
+      return true;
+    }
+    if (o == null || !(o instanceof LocalizedUrlAliases)) {
+      return false;
+    }
+    LocalizedUrlAliases other = (LocalizedUrlAliases) o;
+    return super.equals(other);
+  }
+
+  /**
+   * Flatten this map to a list.
+   *
+   * @return list containing all {@code UrlAlias}es from this object
+   */
+  public List<UrlAlias> flatten() {
+    return this.values().stream().flatMap(list -> list.stream()).collect(Collectors.toList());
   }
 
   public List<Locale> getTargetLanguages() {

--- a/dc-model/src/test/java/de/digitalcollections/model/alias/LocalizedUrlAliasesTest.java
+++ b/dc-model/src/test/java/de/digitalcollections/model/alias/LocalizedUrlAliasesTest.java
@@ -1,0 +1,61 @@
+package de.digitalcollections.model.alias;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
+
+import de.digitalcollections.model.identifiable.IdentifiableType;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Locale;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+
+public class LocalizedUrlAliasesTest {
+
+  @Test
+  public void emptyConstructorTest() {
+    LocalizedUrlAliases o = new LocalizedUrlAliases();
+    assertThat(o).isEmpty();
+  }
+
+  @Test
+  public void parameterizedConstructorTest() {
+    UrlAlias urlAlias = this.createUrlAlias(null, null);
+    LocalizedUrlAliases o = new LocalizedUrlAliases(urlAlias);
+    assertThat(o).containsExactly(entry(Locale.GERMAN, List.of(urlAlias)));
+  }
+
+  @Test
+  public void equalsTest() {
+    UrlAlias u1 = this.createUrlAlias(Locale.ENGLISH, "something"),
+        u2 = this.createUrlAlias(null, "irgendwas"),
+        u3 = this.createUrlAlias(null, "nochwas");
+    LocalizedUrlAliases lua1 = new LocalizedUrlAliases(u1, u2, u3),
+        lua2 = new LocalizedUrlAliases(u1);
+    lua2.add(u2, u3);
+
+    assertThat(lua1.equals(lua2)).isTrue();
+  }
+
+  @Test
+  public void flattenTest() {
+    UrlAlias u1 = this.createUrlAlias(Locale.ENGLISH, "something"),
+        u2 = this.createUrlAlias(null, "irgendwas"),
+        u3 = this.createUrlAlias(null, "nochwas");
+    LocalizedUrlAliases o = new LocalizedUrlAliases(u1, u2, u3);
+
+    assertThat(o.flatten()).containsExactlyInAnyOrder(u1, u2, u3);
+  }
+
+  private UrlAlias createUrlAlias(Locale locale, String slug) {
+    UrlAlias urlAlias = new UrlAlias();
+    urlAlias.setCreated(LocalDateTime.now());
+    urlAlias.setSlug(slug == null ? "test" : slug);
+    urlAlias.setTargetIdentifiableType(IdentifiableType.RESOURCE);
+    urlAlias.setTargetLanguage(locale == null ? Locale.GERMAN : locale);
+    urlAlias.setTargetUuid(UUID.randomUUID());
+    urlAlias.setUuid(UUID.randomUUID());
+    urlAlias.setWebsiteUuid(UUID.randomUUID());
+    return urlAlias;
+  }
+}


### PR DESCRIPTION
...with an own `equals` and two more handy methods. By the way an unittest is added.