### PR TITLE
Add listrequest and listresponse

### DIFF
--- a/dc-model-jackson/src/main/java/de/digitalcollections/model/jackson/DigitalCollectionsModelModule.java
+++ b/dc-model-jackson/src/main/java/de/digitalcollections/model/jackson/DigitalCollectionsModelModule.java
@@ -82,6 +82,8 @@ import de.digitalcollections.model.jackson.mixin.identifiable.resource.VideoFile
 import de.digitalcollections.model.jackson.mixin.identifiable.versioning.VersionMixIn;
 import de.digitalcollections.model.jackson.mixin.identifiable.web.WebpageMixIn;
 import de.digitalcollections.model.jackson.mixin.legal.LicenseMixIn;
+import de.digitalcollections.model.jackson.mixin.list.ListRequestMixIn;
+import de.digitalcollections.model.jackson.mixin.list.ListResponseMixIn;
 import de.digitalcollections.model.jackson.mixin.paging.OrderMixIn;
 import de.digitalcollections.model.jackson.mixin.paging.PageRequestMixIn;
 import de.digitalcollections.model.jackson.mixin.paging.PageResponseMixIn;
@@ -116,6 +118,8 @@ import de.digitalcollections.model.jackson.mixin.view.RenderingHintsMixIn;
 import de.digitalcollections.model.jackson.mixin.view.RenderingHintsPreviewImageMixIn;
 import de.digitalcollections.model.jackson.mixin.view.RenderingTemplateMixIn;
 import de.digitalcollections.model.legal.License;
+import de.digitalcollections.model.list.ListRequest;
+import de.digitalcollections.model.list.ListResponse;
 import de.digitalcollections.model.paging.Order;
 import de.digitalcollections.model.paging.PageRequest;
 import de.digitalcollections.model.paging.PageResponse;
@@ -231,6 +235,8 @@ public class DigitalCollectionsModelModule extends SimpleModule {
     context.setMixInAnnotations(License.class, LicenseMixIn.class);
     context.setMixInAnnotations(LinkedDataFileResource.class, LinkedDataFileResourceMixIn.class);
     context.setMixInAnnotations(ListItem.class, ListItemMixIn.class);
+    context.setMixInAnnotations(ListRequest.class, ListRequestMixIn.class);
+    context.setMixInAnnotations(ListResponse.class, ListResponseMixIn.class);
     context.setMixInAnnotations(
         LocalizedStructuredContent.class, LocalizedStructuredContentMixIn.class);
     context.setMixInAnnotations(LocalizedText.class, LocalizedTextMixIn.class);

--- a/dc-model-jackson/src/main/java/de/digitalcollections/model/jackson/mixin/list/ListRequestMixIn.java
+++ b/dc-model-jackson/src/main/java/de/digitalcollections/model/jackson/mixin/list/ListRequestMixIn.java
@@ -1,0 +1,9 @@
+package de.digitalcollections.model.jackson.mixin.list;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import de.digitalcollections.model.list.ListRequest;
+
+@JsonDeserialize(as = ListRequest.class)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public abstract class ListRequestMixIn {}

--- a/dc-model-jackson/src/main/java/de/digitalcollections/model/jackson/mixin/list/ListResponseMixIn.java
+++ b/dc-model-jackson/src/main/java/de/digitalcollections/model/jackson/mixin/list/ListResponseMixIn.java
@@ -1,0 +1,71 @@
+package de.digitalcollections.model.jackson.mixin.list;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonSubTypes.Type;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import de.digitalcollections.model.identifiable.Identifiable;
+import de.digitalcollections.model.identifiable.IdentifierType;
+import de.digitalcollections.model.identifiable.agent.FamilyName;
+import de.digitalcollections.model.identifiable.agent.GivenName;
+import de.digitalcollections.model.identifiable.entity.Article;
+import de.digitalcollections.model.identifiable.entity.Collection;
+import de.digitalcollections.model.identifiable.entity.DigitalObject;
+import de.digitalcollections.model.identifiable.entity.Entity;
+import de.digitalcollections.model.identifiable.entity.Project;
+import de.digitalcollections.model.identifiable.entity.Topic;
+import de.digitalcollections.model.identifiable.entity.Website;
+import de.digitalcollections.model.identifiable.entity.agent.CorporateBody;
+import de.digitalcollections.model.identifiable.entity.agent.Person;
+import de.digitalcollections.model.identifiable.entity.geo.location.GeoLocation;
+import de.digitalcollections.model.identifiable.entity.geo.location.HumanSettlement;
+import de.digitalcollections.model.identifiable.entity.relation.EntityRelation;
+import de.digitalcollections.model.identifiable.entity.work.Item;
+import de.digitalcollections.model.identifiable.entity.work.Work;
+import de.digitalcollections.model.identifiable.resource.FileResource;
+import de.digitalcollections.model.identifiable.web.Webpage;
+import de.digitalcollections.model.list.ListResponse;
+import de.digitalcollections.model.paging.Sorting;
+import de.digitalcollections.model.security.User;
+import de.digitalcollections.model.view.RenderingTemplate;
+import java.util.List;
+
+@JsonDeserialize(as = ListResponse.class)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public abstract class ListResponseMixIn<T> extends ListResponse<T> {
+
+  @JsonTypeInfo(use = Id.NAME, property = "objectType", visible = true)
+  @JsonSubTypes({
+    @Type(value = Article.class, name = "ARTICLE"),
+    @Type(value = Collection.class, name = "COLLECTION"),
+    @Type(value = CorporateBody.class, name = "CORPORATE_BODY"),
+    @Type(value = DigitalObject.class, name = "DIGITAL_OBJECT"),
+    @Type(value = Entity.class, name = "ENTITY"),
+    @Type(value = EntityRelation.class, name = "ENTITY_RELATION"),
+    @Type(value = FamilyName.class, name = "FAMILY_NAME"),
+    @Type(value = FileResource.class, name = "FILE_RESOURCE"),
+    @Type(value = GeoLocation.class, name = "GEO_LOCATION"),
+    @Type(value = GivenName.class, name = "GIVEN_NAME"),
+    @Type(value = HumanSettlement.class, name = "HUMAN_SETTLEMENT"),
+    @Type(value = Identifiable.class, name = "IDENTIFIABLE"),
+    @Type(value = IdentifierType.class, name = "IDENTIFIER_TYPE"),
+    @Type(value = Item.class, name = "ITEM"),
+    @Type(value = Person.class, name = "PERSON"),
+    @Type(value = Project.class, name = "PROJECT"),
+    @Type(value = RenderingTemplate.class, name = "RENDERING_TEMPLATE"),
+    @Type(value = Topic.class, name = "TOPIC"),
+    @Type(value = User.class, name = "USER"),
+    @Type(value = Webpage.class, name = "WEBPAGE"),
+    @Type(value = Website.class, name = "WEBSITE"),
+    @Type(value = Work.class, name = "WORK")
+  })
+  @Override
+  public abstract List<T> getContent();
+
+  @JsonIgnore
+  @Override
+  public abstract Sorting getSorting();
+}

--- a/dc-model-jackson/src/test/java/de/digitalcollections/model/jackson/list/ListRequestTest.java
+++ b/dc-model-jackson/src/test/java/de/digitalcollections/model/jackson/list/ListRequestTest.java
@@ -1,0 +1,28 @@
+package de.digitalcollections.model.jackson.list;
+
+import de.digitalcollections.model.filter.Filtering;
+import de.digitalcollections.model.jackson.BaseJsonSerializationTest;
+import de.digitalcollections.model.list.ListRequest;
+import de.digitalcollections.model.paging.Direction;
+import de.digitalcollections.model.paging.Order;
+import de.digitalcollections.model.paging.Sorting;
+import org.junit.jupiter.api.Test;
+
+public class ListRequestTest extends BaseJsonSerializationTest {
+
+  private ListRequest createObject() {
+    ListRequest listRequest = new ListRequest();
+    listRequest.add(Filtering.defaultBuilder().filter("label").startsWith("A").build());
+    listRequest.add(
+        Sorting.defaultBuilder()
+            .order(Order.defaultBuilder().direction(Direction.ASC).property("label").build())
+            .build());
+    return listRequest;
+  }
+
+  @Test
+  public void testSerializeDeserialize() throws Exception {
+    ListRequest listRequest = createObject();
+    checkSerializeDeserialize(listRequest, "serializedTestObjects/list/ListRequest.json");
+  }
+}

--- a/dc-model-jackson/src/test/java/de/digitalcollections/model/jackson/list/ListResponseTest.java
+++ b/dc-model-jackson/src/test/java/de/digitalcollections/model/jackson/list/ListResponseTest.java
@@ -1,0 +1,48 @@
+package de.digitalcollections.model.jackson.list;
+
+import de.digitalcollections.model.filter.FilterCriterion;
+import de.digitalcollections.model.filter.FilterOperation;
+import de.digitalcollections.model.filter.Filtering;
+import de.digitalcollections.model.jackson.BaseJsonSerializationTest;
+import de.digitalcollections.model.list.ListRequest;
+import de.digitalcollections.model.list.ListResponse;
+import de.digitalcollections.model.security.User;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+public class ListResponseTest extends BaseJsonSerializationTest {
+
+  private ListResponse<User> createObject() {
+    ListRequest listRequest = new ListRequest();
+    // filtering
+    FilterCriterion filterCriteria1 =
+        new FilterCriterion("longField", FilterOperation.EQUALS, 5L, null, null, null);
+    FilterCriterion filterCriteria2 =
+        new FilterCriterion(
+            "dateField",
+            FilterOperation.BETWEEN,
+            null,
+            LocalDate.parse("2020-01-01"),
+            LocalDate.parse("2020-01-31"),
+            null);
+    Filtering filtering =
+        Filtering.defaultBuilder().add(filterCriteria1).add(filterCriteria2).build();
+    listRequest.setFiltering(filtering);
+
+    List<User> content = new ArrayList<>();
+    User user = new User();
+    user.setEmail("test@user.de");
+    content.add(user);
+
+    ListResponse listResponse = new ListResponse(content, listRequest);
+    return listResponse;
+  }
+
+  @Test
+  public void testSerializeDeserialize() throws Exception {
+    ListResponse<User> listResponse = createObject();
+    checkSerializeDeserialize(listResponse, "serializedTestObjects/list/ListResponse.json");
+  }
+}

--- a/dc-model-jackson/src/test/java/de/digitalcollections/model/jackson/paging/SearchPageResponseTest.java
+++ b/dc-model-jackson/src/test/java/de/digitalcollections/model/jackson/paging/SearchPageResponseTest.java
@@ -4,6 +4,7 @@ import de.digitalcollections.model.identifiable.Identifiable;
 import de.digitalcollections.model.identifiable.entity.DigitalObject;
 import de.digitalcollections.model.identifiable.web.Webpage;
 import de.digitalcollections.model.jackson.BaseJsonSerializationTest;
+import de.digitalcollections.model.paging.SearchPageRequest;
 import de.digitalcollections.model.paging.SearchPageResponse;
 import java.util.ArrayList;
 import java.util.List;
@@ -24,7 +25,9 @@ public class SearchPageResponseTest extends BaseJsonSerializationTest {
     webpage.setLabel("Webpage-Label");
     content.add(webpage);
 
+    SearchPageRequest pageRequest = new SearchPageRequest("Label", 3, 15, null);
     SearchPageResponse<Identifiable> resp = new SearchPageResponse<>();
+    resp.setPageRequest(pageRequest);
     resp.setContent(content);
     resp.setTotalElements(2);
 

--- a/dc-model-jackson/src/test/resources/serializedTestObjects/list/ListRequest.json
+++ b/dc-model-jackson/src/test/resources/serializedTestObjects/list/ListRequest.json
@@ -1,0 +1,19 @@
+{
+  "filtering" : {
+    "filterCriteria" : [ {
+      "fieldName" : "label",
+      "operation" : "STARTS_WITH",
+      "value" : "A"
+    } ]
+  },
+  "sorting" : {
+    "orders" : [ {
+      "direction" : "ASC",
+      "ignoreCase" : false,
+      "nullHandling" : "NATIVE",
+      "property" : "label",
+      "ascending" : true,
+      "descending" : false
+    } ]
+  }
+}

--- a/dc-model-jackson/src/test/resources/serializedTestObjects/list/ListRequest.json
+++ b/dc-model-jackson/src/test/resources/serializedTestObjects/list/ListRequest.json
@@ -1,7 +1,8 @@
 {
   "filtering" : {
     "filterCriteria" : [ {
-      "fieldName" : "label",
+      "expression" : "label",
+      "nativeExpression" : false,
       "operation" : "STARTS_WITH",
       "value" : "A"
     } ]

--- a/dc-model-jackson/src/test/resources/serializedTestObjects/list/ListResponse.json
+++ b/dc-model-jackson/src/test/resources/serializedTestObjects/list/ListResponse.json
@@ -1,0 +1,23 @@
+{
+  "content" : [ {
+    "objectType" : "USER",
+    "email" : "test@user.de",
+    "enabled" : true,
+    "roles" : [ ]
+  } ],
+  "listRequest" : {
+    "filtering" : {
+      "filterCriteria" : [ {
+        "fieldName" : "longField",
+        "operation" : "EQUALS",
+        "value" : [ "java.lang.Long", 5 ]
+      }, {
+        "fieldName" : "dateField",
+        "operation" : "BETWEEN",
+        "minValue" : [ "java.time.LocalDate", "2020-01-01" ],
+        "maxValue" : [ "java.time.LocalDate", "2020-01-31" ]
+      } ]
+    }
+  },
+  "totalElements" : 1
+}

--- a/dc-model-jackson/src/test/resources/serializedTestObjects/list/ListResponse.json
+++ b/dc-model-jackson/src/test/resources/serializedTestObjects/list/ListResponse.json
@@ -8,11 +8,13 @@
   "listRequest" : {
     "filtering" : {
       "filterCriteria" : [ {
-        "fieldName" : "longField",
+        "expression" : "longField",
+        "nativeExpression" : false,
         "operation" : "EQUALS",
         "value" : [ "java.lang.Long", 5 ]
       }, {
-        "fieldName" : "dateField",
+        "expression" : "dateField",
+        "nativeExpression" : false,
         "operation" : "BETWEEN",
         "minValue" : [ "java.time.LocalDate", "2020-01-01" ],
         "maxValue" : [ "java.time.LocalDate", "2020-01-31" ]

--- a/dc-model-jackson/src/test/resources/serializedTestObjects/paging/SearchPageResponse.json
+++ b/dc-model-jackson/src/test/resources/serializedTestObjects/paging/SearchPageResponse.json
@@ -17,5 +17,10 @@
     },
     "type" : "RESOURCE"
   } ],
+  "pageRequest" : {
+    "pageNumber" : 3,
+    "pageSize" : 15,
+    "query" : "Label"
+  },
   "totalElements" : 2
 }

--- a/dc-model/src/main/java/de/digitalcollections/model/list/ListRequest.java
+++ b/dc-model/src/main/java/de/digitalcollections/model/list/ListRequest.java
@@ -1,0 +1,148 @@
+package de.digitalcollections.model.list;
+
+import de.digitalcollections.model.filter.FilterCriterion;
+import de.digitalcollections.model.filter.Filtering;
+import de.digitalcollections.model.paging.Direction;
+import de.digitalcollections.model.paging.PageRequest;
+import de.digitalcollections.model.paging.Sorting;
+import java.io.Serializable;
+import java.util.List;
+
+/**
+ * Container for querying a optionally filtered and sorted list:
+ *
+ * <ul>
+ *   <li>filtering: container for filter criterias of result list
+ *   <li>sorting: container for sorting order of result list
+ * </ul>
+ */
+public class ListRequest implements Serializable {
+
+  protected Filtering filtering;
+  protected Sorting sorting;
+
+  public ListRequest() {}
+
+  /**
+   * Creates a new {@link PageRequest} with sorting parameters applied.
+   *
+   * @param direction the direction of the {@link Sorting} to be specified, can be {@literal null}.
+   * @param properties the properties to sorting by, must not be {@literal null} or empty.
+   */
+  public ListRequest(Direction direction, String... properties) {
+    this(new Sorting(direction, properties), null);
+  }
+
+  public ListRequest(Sorting sorting) {
+    this(sorting, null);
+  }
+
+  /**
+   * Creates a new {@link PageRequest} with sorting parameters applied.
+   *
+   * @param sorting can be {@literal null}
+   * @param filtering contains list of filter criterias
+   */
+  public ListRequest(Sorting sorting, Filtering filtering) {
+    this.filtering = filtering;
+    this.sorting = sorting;
+  }
+
+  /**
+   * Add all filter criteria of given filtering to existing filtering. Initialise if no existing
+   * filtering.
+   *
+   * @param filtering new filtering criteria to add
+   * @return all filtering criteria
+   */
+  public List<FilterCriterion> add(Filtering filtering) {
+    Filtering existingFiltering = getFiltering();
+    if (existingFiltering == null || existingFiltering.getFilterCriteria().isEmpty()) {
+      setFiltering(filtering);
+    } else {
+      existingFiltering.add(filtering);
+    }
+    // FIXME (breaking change): return this?
+    return getFiltering().getFilterCriteria();
+  }
+
+  /**
+   * Add all sorting criteria of given sorting to existing sorting. Initialise if no existing
+   * filtering.
+   *
+   * @param sorting new sorting criteria to add
+   * @return all sorting criteria
+   */
+  public ListRequest add(Sorting sorting) {
+    Sorting existingSorting = getSorting();
+    if (existingSorting == null || existingSorting.getOrders().isEmpty()) {
+      setSorting(sorting);
+    } else {
+      existingSorting.and(sorting);
+    }
+    return this;
+  }
+
+  @Override
+  public boolean equals(final Object obj) {
+
+    if (this == obj) {
+      return true;
+    }
+
+    if (!(obj instanceof ListRequest)) {
+      return false;
+    }
+
+    ListRequest that = (ListRequest) obj;
+
+    boolean filterEqual =
+        (this.filtering == null ? that.filtering == null : this.filtering.equals(that.filtering));
+    boolean sortEqual =
+        (this.sorting == null ? that.sorting == null : this.sorting.equals(that.sorting));
+    return filterEqual && sortEqual;
+  }
+
+  /** @return the filtering parameters */
+  public Filtering getFiltering() {
+    return filtering;
+  }
+
+  /** @return the sorting parameters */
+  public Sorting getSorting() {
+    return sorting;
+  }
+
+  /** @return whether the page request has defined any sorting. */
+  public boolean hasSorting() {
+    return !(sorting == null || sorting.getOrders() == null || sorting.getOrders().isEmpty());
+  }
+
+  @Override
+  public int hashCode() {
+    final int prime = 31;
+    int result = 1;
+
+    return prime * result
+        + (null == sorting ? 0 : sorting.hashCode())
+        + (null == filtering ? 0 : filtering.hashCode());
+  }
+
+  /** @param filtering the filtering criterias */
+  public void setFiltering(Filtering filtering) {
+    this.filtering = filtering;
+  }
+
+  /** @param sorting the sorting parameters */
+  public void setSorting(Sorting sorting) {
+    this.sorting = sorting;
+  }
+
+  @Override
+  public String toString() {
+    return String.format(
+        "List request [sorting: %s, filtering: %s]",
+        sorting == null ? null : sorting.toString(),
+        filtering == null ? null : filtering.toString());
+  }
+}

--- a/dc-model/src/main/java/de/digitalcollections/model/list/ListRequest.java
+++ b/dc-model/src/main/java/de/digitalcollections/model/list/ListRequest.java
@@ -1,11 +1,9 @@
 package de.digitalcollections.model.list;
 
-import de.digitalcollections.model.filter.FilterCriterion;
 import de.digitalcollections.model.filter.Filtering;
 import de.digitalcollections.model.paging.Direction;
 import de.digitalcollections.model.paging.Sorting;
 import java.io.Serializable;
-import java.util.List;
 
 /**
  * Container for querying a optionally filtered and sorted list:
@@ -52,25 +50,24 @@ public class ListRequest implements Serializable {
    * filtering.
    *
    * @param filtering new filtering criteria to add
-   * @return all filtering criteria
+   * @return the updated ListRequest instance
    */
-  public List<FilterCriterion> add(Filtering filtering) {
+  public ListRequest add(Filtering filtering) {
     Filtering existingFiltering = getFiltering();
     if (existingFiltering == null || existingFiltering.getFilterCriteria().isEmpty()) {
       setFiltering(filtering);
     } else {
       existingFiltering.add(filtering);
     }
-    // FIXME (breaking change): return this?
-    return getFiltering().getFilterCriteria();
+    return this;
   }
 
   /**
    * Add all sorting criteria of given sorting to existing sorting. Initialise if no existing
-   * filtering.
+   * sorting.
    *
    * @param sorting new sorting criteria to add
-   * @return all sorting criteria
+   * @return the updated ListRequest instance
    */
   public ListRequest add(Sorting sorting) {
     Sorting existingSorting = getSorting();

--- a/dc-model/src/main/java/de/digitalcollections/model/list/ListRequest.java
+++ b/dc-model/src/main/java/de/digitalcollections/model/list/ListRequest.java
@@ -3,7 +3,6 @@ package de.digitalcollections.model.list;
 import de.digitalcollections.model.filter.FilterCriterion;
 import de.digitalcollections.model.filter.Filtering;
 import de.digitalcollections.model.paging.Direction;
-import de.digitalcollections.model.paging.PageRequest;
 import de.digitalcollections.model.paging.Sorting;
 import java.io.Serializable;
 import java.util.List;
@@ -24,7 +23,7 @@ public class ListRequest implements Serializable {
   public ListRequest() {}
 
   /**
-   * Creates a new {@link PageRequest} with sorting parameters applied.
+   * Creates a new {@link ListRequest} with sorting parameters applied.
    *
    * @param direction the direction of the {@link Sorting} to be specified, can be {@literal null}.
    * @param properties the properties to sorting by, must not be {@literal null} or empty.
@@ -38,7 +37,7 @@ public class ListRequest implements Serializable {
   }
 
   /**
-   * Creates a new {@link PageRequest} with sorting parameters applied.
+   * Creates a new {@link ListRequest} with sorting parameters applied.
    *
    * @param sorting can be {@literal null}
    * @param filtering contains list of filter criterias
@@ -113,9 +112,16 @@ public class ListRequest implements Serializable {
     return sorting;
   }
 
-  /** @return whether the page request has defined any sorting. */
+  /** @return whether the request has defined any filtering. */
+  public boolean hasFiltering() {
+    return filtering != null
+        && filtering.getFilterCriteria() != null
+        && !filtering.getFilterCriteria().isEmpty();
+  }
+
+  /** @return whether the request has defined any sorting. */
   public boolean hasSorting() {
-    return !(sorting == null || sorting.getOrders() == null || sorting.getOrders().isEmpty());
+    return sorting != null && sorting.getOrders() != null && !sorting.getOrders().isEmpty();
   }
 
   @Override

--- a/dc-model/src/main/java/de/digitalcollections/model/list/ListResponse.java
+++ b/dc-model/src/main/java/de/digitalcollections/model/list/ListResponse.java
@@ -1,0 +1,135 @@
+package de.digitalcollections.model.list;
+
+import de.digitalcollections.model.paging.Sorting;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+
+/**
+ * Container for list information.
+ *
+ * @param <T> object type of list items
+ */
+public class ListResponse<T> implements Iterable<T> {
+
+  protected List<T> content = new ArrayList<>();
+  protected ListRequest listRequest;
+  protected long total;
+
+  public ListResponse() {
+    this.listRequest = null;
+    this.total = 0;
+  }
+
+  /**
+   * Constructor with the given content and the given governing {@link ListRequest}.
+   *
+   * @param content the content of this list, must not be {@literal null}.
+   * @param listRequest the request information, can be {@literal null}.
+   */
+  public ListResponse(List<T> content, ListRequest listRequest) {
+    assert content != null : "content must not be null!";
+
+    this.content.addAll(content);
+    this.listRequest = listRequest;
+    this.total = content.size();
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj) {
+      return true;
+    }
+    if (!(obj instanceof ListResponse<?>)) {
+      return false;
+    }
+
+    ListResponse<?> that = (ListResponse<?>) obj;
+
+    boolean contentEqual = this.content.equals(that.content);
+    boolean listRequestEqual =
+        this.listRequest == null
+            ? that.listRequest == null
+            : this.listRequest.equals(that.listRequest);
+
+    return (this.total == that.total) && contentEqual && listRequestEqual;
+  }
+
+  /** @return the content as {@link List}. */
+  public List<T> getContent() {
+    return Collections.unmodifiableList(content);
+  }
+
+  /** @return the ListRequest used to get this ListResponse */
+  public ListRequest getListRequest() {
+    return listRequest;
+  }
+
+  /** @return the sorting parameters for the {@link ListResponse}. */
+  public Sorting getSorting() {
+    return listRequest == null ? null : listRequest.getSorting();
+  }
+
+  /**
+   * Returns the total amount of elements.
+   *
+   * @return the total amount of elements
+   */
+  public long getTotalElements() {
+    return total;
+  }
+
+  /** @return whether the {@link ListResponse} has content at all. */
+  public boolean hasContent() {
+    return !content.isEmpty();
+  }
+
+  @Override
+  public int hashCode() {
+
+    int result = 17;
+
+    result += 31 * (int) (total ^ total >>> 32);
+    result += 31 * (listRequest == null ? 0 : listRequest.hashCode());
+    result += 31 * content.hashCode();
+
+    return result;
+  }
+
+  @Override
+  public Iterator<T> iterator() {
+    return content.iterator();
+  }
+
+  /**
+   * Allows to set the content (needed in case of content has to be converted/casted)
+   *
+   * @param content list of content/objects
+   */
+  public void setContent(List<T> content) {
+    this.content = content;
+  }
+
+  public void setListRequest(ListRequest listRequest) {
+    this.listRequest = listRequest;
+  }
+
+  public void setTotalElements(long totalElements) {
+    this.total = totalElements;
+  }
+
+  @Override
+  public String toString() {
+
+    String contentType = "UNKNOWN";
+    List<T> unmodifiableContent = getContent();
+
+    if (unmodifiableContent.size() > 0) {
+      contentType = unmodifiableContent.get(0).getClass().getName();
+    }
+
+    return String.format(
+        "List of %s containing %d instances", contentType, unmodifiableContent.size());
+  }
+}

--- a/dc-model/src/main/java/de/digitalcollections/model/paging/Order.java
+++ b/dc-model/src/main/java/de/digitalcollections/model/paging/Order.java
@@ -19,7 +19,7 @@ public class Order {
 
   private Direction direction;
   private boolean ignoreCase;
-  private NullHandling nullHandling;
+  private NullHandling nullHandling = NullHandling.NATIVE;
   private String property;
   private String subProperty = null;
 
@@ -29,7 +29,7 @@ public class Order {
       Direction direction, boolean ignoreCase, NullHandling nullHandling, String property) {
     this.direction = direction;
     this.ignoreCase = ignoreCase;
-    this.nullHandling = nullHandling;
+    this.nullHandling = nullHandling == null ? NullHandling.NATIVE : nullHandling;
     this.property = property;
   }
 

--- a/dc-model/src/main/java/de/digitalcollections/model/paging/PageResponse.java
+++ b/dc-model/src/main/java/de/digitalcollections/model/paging/PageResponse.java
@@ -1,8 +1,6 @@
 package de.digitalcollections.model.paging;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Iterator;
+import de.digitalcollections.model.list.ListResponse;
 import java.util.List;
 
 /**
@@ -11,19 +9,17 @@ import java.util.List;
  *
  * @param <T> object type listed in page
  */
-public class PageResponse<T> implements Iterable<T> {
+public class PageResponse<T> extends ListResponse<T> {
 
-  private List<T> content = new ArrayList<>();
-  private PageRequest pageRequest;
-  private long total;
+  protected PageRequest pageRequest;
 
   public PageResponse() {
+    super();
     this.pageRequest = null;
-    this.total = 0;
   }
 
   /**
-   * Constructor of {@code PageResponseImpl} with the given content and the given governing {@link
+   * Constructor of {@code PageResponse} with the given content and the given governing {@link
    * PageRequest}.
    *
    * @param content the content of this page, must not be {@literal null}.
@@ -33,9 +29,8 @@ public class PageResponse<T> implements Iterable<T> {
    *     place to mitigate inconsistencies
    */
   public PageResponse(List<T> content, PageRequest pageRequest, long total) {
-    assert content != null : "content must not be null!";
+    super(content, null);
 
-    this.content.addAll(content);
     this.pageRequest = pageRequest;
     this.total =
         !content.isEmpty()
@@ -57,11 +52,9 @@ public class PageResponse<T> implements Iterable<T> {
 
   @Override
   public boolean equals(Object obj) {
-
     if (this == obj) {
       return true;
     }
-
     if (!(obj instanceof PageResponse<?>)) {
       return false;
     }
@@ -75,11 +68,6 @@ public class PageResponse<T> implements Iterable<T> {
             : this.pageRequest.equals(that.pageRequest);
 
     return (this.total == that.total) && contentEqual && pageRequestEqual;
-  }
-
-  /** @return the page content/objects as {@link List}. */
-  public List<T> getContent() {
-    return Collections.unmodifiableList(content);
   }
 
   /**
@@ -114,20 +102,6 @@ public class PageResponse<T> implements Iterable<T> {
     return pageRequest == null ? 0 : pageRequest.getPageSize();
   }
 
-  /** @return the sorting parameters for the {@link PageResponse}. */
-  public Sorting getSorting() {
-    return pageRequest == null ? null : pageRequest.getSorting();
-  }
-
-  /**
-   * Returns the total amount of elements.
-   *
-   * @return the total amount of elements
-   */
-  public long getTotalElements() {
-    return total;
-  }
-
   /**
    * Returns the number of total pages.
    *
@@ -135,15 +109,6 @@ public class PageResponse<T> implements Iterable<T> {
    */
   public int getTotalPages() {
     return getSize() == 0 ? 1 : (int) Math.ceil((double) total / (double) getSize());
-  }
-
-  /**
-   * Returns whether the {@link PageResponse} has content at all.
-   *
-   * @return whether the {@link PageResponse} has content at all.
-   */
-  public boolean hasContent() {
-    return !content.isEmpty();
   }
 
   /**
@@ -194,11 +159,6 @@ public class PageResponse<T> implements Iterable<T> {
     return !hasNext();
   }
 
-  @Override
-  public Iterator<T> iterator() {
-    return content.iterator();
-  }
-
   /**
    * Returns the {@link PageRequest} to request the next {@link PageResponse}. Can be {@literal
    * null} in case the current {@link PageResponse} is already the last one. Clients should check
@@ -226,21 +186,8 @@ public class PageResponse<T> implements Iterable<T> {
     return null;
   }
 
-  /**
-   * Allows to set the content (needed in case of content has to be converted/casted)
-   *
-   * @param content list of content/objects of this page
-   */
-  public void setContent(List<T> content) {
-    this.content = content;
-  }
-
   public void setPageRequest(PageRequest pageRequest) {
     this.pageRequest = pageRequest;
-  }
-
-  public void setTotalElements(long totalElements) {
-    this.total = totalElements;
   }
 
   @Override

--- a/dc-model/src/main/java/de/digitalcollections/model/paging/SearchPageResponse.java
+++ b/dc-model/src/main/java/de/digitalcollections/model/paging/SearchPageResponse.java
@@ -14,10 +14,13 @@ public class SearchPageResponse<T> extends PageResponse<T> {
     super(content, searchPageRequest, total);
   }
 
+  @Deprecated(since = "9.1.0", forRemoval = true)
+  /** @deprecated use ((SearchPageRequest) getPageRequest()).getQuery() instead. */
   public String getQuery() {
     return query;
   }
 
+  @Deprecated(since = "9.1.0", forRemoval = true)
   public void setQuery(String query) {
     this.query = query;
   }

--- a/dc-model/src/main/java/de/digitalcollections/model/paging/SearchPageResponse.java
+++ b/dc-model/src/main/java/de/digitalcollections/model/paging/SearchPageResponse.java
@@ -14,12 +14,16 @@ public class SearchPageResponse<T> extends PageResponse<T> {
     super(content, searchPageRequest, total);
   }
 
-  @Deprecated(since = "9.1.0", forRemoval = true)
   /** @deprecated use ((SearchPageRequest) getPageRequest()).getQuery() instead. */
+  @Deprecated(since = "9.1.0", forRemoval = true)
   public String getQuery() {
     return query;
   }
 
+  /**
+   * @param query query term
+   * @deprecated use ((SearchPageRequest) getPageRequest()).setQuery() instead.
+   */
   @Deprecated(since = "9.1.0", forRemoval = true)
   public void setQuery(String query) {
     this.query = query;


### PR DESCRIPTION
- add ListRequest as parent to PageRequest (without paging params) (for full list)
- add ListResponse as parent to PageResponse (without paging params) (for full list)
- rename "sort" field to "sorting"
- Set query field in SearchPageResponse to deprecated (close issue #215 )

no compile problems in cudami (using this library)