### PR TITLE
Fix `equals` in LocalizedUrlAliases

### DIFF
--- a/dc-model/src/main/java/de/digitalcollections/model/identifiable/alias/LocalizedUrlAliases.java
+++ b/dc-model/src/main/java/de/digitalcollections/model/identifiable/alias/LocalizedUrlAliases.java
@@ -13,11 +13,6 @@ public class LocalizedUrlAliases extends HashMap<Locale, List<UrlAlias>> {
     super();
   }
 
-  /**
-   * Constructor, can be called without parameters as well, i.e. {@code new LocalizedUrlAliases()}
-   *
-   * @param urlAliases Not {@code null}
-   */
   public LocalizedUrlAliases(UrlAlias... urlAliases) {
     super();
     this.add(urlAliases);
@@ -58,7 +53,16 @@ public class LocalizedUrlAliases extends HashMap<Locale, List<UrlAlias>> {
       return false;
     }
     LocalizedUrlAliases other = (LocalizedUrlAliases) o;
-    return super.equals(other);
+    try {
+      if (this.flatten().size() != other.flatten().size()) {
+        return false;
+      }
+      return flatten().containsAll(other.flatten());
+    } catch (NullPointerException unused) {
+      return false;
+    } catch (ClassCastException unused) {
+      return false;
+    }
   }
 
   /**

--- a/dc-model/src/test/java/de/digitalcollections/model/identifiable/alias/LocalizedUrlAliasesTest.java
+++ b/dc-model/src/test/java/de/digitalcollections/model/identifiable/alias/LocalizedUrlAliasesTest.java
@@ -35,7 +35,7 @@ public class LocalizedUrlAliasesTest {
         lua2 = new LocalizedUrlAliases(u1);
     lua2.add(u3, u2);
 
-    assertThat(lua1.equals(lua2)).isTrue();
+    assertThat(lua1).isEqualTo(lua2);
   }
 
   @Test

--- a/dc-model/src/test/java/de/digitalcollections/model/identifiable/alias/LocalizedUrlAliasesTest.java
+++ b/dc-model/src/test/java/de/digitalcollections/model/identifiable/alias/LocalizedUrlAliasesTest.java
@@ -21,28 +21,28 @@ public class LocalizedUrlAliasesTest {
 
   @Test
   public void parameterizedConstructorTest() {
-    UrlAlias urlAlias = this.createUrlAlias(null, null);
+    UrlAlias urlAlias = createUrlAlias(null, null);
     LocalizedUrlAliases o = new LocalizedUrlAliases(urlAlias);
     assertThat(o).containsExactly(entry(Locale.GERMAN, List.of(urlAlias)));
   }
 
   @Test
   public void equalsTest() {
-    UrlAlias u1 = this.createUrlAlias(Locale.ENGLISH, "something"),
-        u2 = this.createUrlAlias(null, "irgendwas"),
-        u3 = this.createUrlAlias(null, "nochwas");
+    UrlAlias u1 = createUrlAlias(Locale.ENGLISH, "something"),
+        u2 = createUrlAlias(null, "something-else"),
+        u3 = createUrlAlias(null, "another-something");
     LocalizedUrlAliases lua1 = new LocalizedUrlAliases(u1, u2, u3),
         lua2 = new LocalizedUrlAliases(u1);
-    lua2.add(u2, u3);
+    lua2.add(u3, u2);
 
     assertThat(lua1.equals(lua2)).isTrue();
   }
 
   @Test
   public void flattenTest() {
-    UrlAlias u1 = this.createUrlAlias(Locale.ENGLISH, "something"),
-        u2 = this.createUrlAlias(null, "irgendwas"),
-        u3 = this.createUrlAlias(null, "nochwas");
+    UrlAlias u1 = createUrlAlias(Locale.ENGLISH, "something"),
+        u2 = createUrlAlias(null, "something-else"),
+        u3 = createUrlAlias(null, "another-something");
     LocalizedUrlAliases o = new LocalizedUrlAliases(u1, u2, u3);
 
     assertThat(o.flatten()).containsExactlyInAnyOrder(u1, u2, u3);


### PR DESCRIPTION
Currently two `LocalizedUrlAliases` objects that are extending `Map` are compared by using Map's `equals` method. This leads to a list comparison where the order of the entries matters (of course, because lists consider their sorting). However, we do not care about the sorting. It only matters that the objects contain equal `UrlAlias` objects. This PR implements the desired behaviour. 