### PR TITLE
Move navDate to Entity

### DIFF
--- a/dc-model/src/main/java/de/digitalcollections/model/identifiable/entity/DigitalObject.java
+++ b/dc-model/src/main/java/de/digitalcollections/model/identifiable/entity/DigitalObject.java
@@ -6,7 +6,6 @@ import de.digitalcollections.model.identifiable.resource.LinkedDataFileResource;
 import de.digitalcollections.model.identifiable.versioning.Version;
 import de.digitalcollections.model.legal.License;
 import de.digitalcollections.model.production.CreationInfo;
-import java.time.LocalDate;
 import java.util.ArrayList;
 
 /**
@@ -55,9 +54,6 @@ public class DigitalObject extends Entity {
 
   /** Details about the creation of the digital object: Who created it, when and where. */
   private CreationInfo creationInfo;
-
-  /** A "navigable" date, required when you need to the display the digital object on a timeline. */
-  private LocalDate navDate;
 
   /** Default constructor, which also sets the EntityType to {@link EntityType#DIGITAL_OBJECT} */
   public DigitalObject() {
@@ -189,20 +185,6 @@ public class DigitalObject extends Entity {
    */
   public void setCreationInfo(CreationInfo creationInfo) {
     this.creationInfo = creationInfo;
-  }
-
-  /** @return a date for "navigation" purposes, e.g. a timeline */
-  public LocalDate getNavDate() {
-    return navDate;
-  }
-
-  /**
-   * Sets the "navigation" date
-   *
-   * @param navDate the "navigation" date
-   */
-  public void setNavDate(LocalDate navDate) {
-    this.navDate = navDate;
   }
 
   @Override

--- a/dc-model/src/main/java/de/digitalcollections/model/identifiable/entity/Entity.java
+++ b/dc-model/src/main/java/de/digitalcollections/model/identifiable/entity/Entity.java
@@ -2,6 +2,7 @@ package de.digitalcollections.model.identifiable.entity;
 
 import de.digitalcollections.model.identifiable.Identifiable;
 import de.digitalcollections.model.identifiable.IdentifiableType;
+import java.time.LocalDate;
 import java.util.Objects;
 
 /**
@@ -21,6 +22,9 @@ public class Entity extends Identifiable {
 
   protected CustomAttributes customAttributes;
   protected EntityType entityType;
+  /** A "navigable" date, required when you need to the display the digital object on a timeline. */
+  protected LocalDate navDate;
+
   protected long refId;
 
   public Entity() {
@@ -119,6 +123,20 @@ public class Entity extends Identifiable {
   /** @param entityType the type of the entity */
   public void setEntityType(EntityType entityType) {
     this.entityType = entityType;
+  }
+
+  /** @return a date for "navigation" purposes, e.g. a timeline */
+  public LocalDate getNavDate() {
+    return navDate;
+  }
+
+  /**
+   * Sets the "navigation" date
+   *
+   * @param navDate the "navigation" date
+   */
+  public void setNavDate(LocalDate navDate) {
+    this.navDate = navDate;
   }
 
   /** @param refId system wide unique entity reference id. */


### PR DESCRIPTION
navDate is a generally useful field for all entities, especially work, item, manifestation, digitalobject. as it is an optional field it can be empty depending on usecase.