### PR TITLE
Reintroduce missing ResourceIOException

### DIFF
--- a/dc-model/src/main/java/de/digitalcollections/model/exception/ResourceIOException.java
+++ b/dc-model/src/main/java/de/digitalcollections/model/exception/ResourceIOException.java
@@ -1,0 +1,20 @@
+package de.digitalcollections.model.exception;
+
+import java.io.IOException;
+
+public class ResourceIOException extends IOException {
+
+  public ResourceIOException() {}
+
+  public ResourceIOException(String message) {
+    super(message);
+  }
+
+  public ResourceIOException(String message, Throwable cause) {
+    super(message, cause);
+  }
+
+  public ResourceIOException(Throwable cause) {
+    super(cause);
+  }
+}


### PR DESCRIPTION
Reintroduce Exception because too many projects rely on it.