### PR TITLE
Remove `Entity.entityType` field (deprecated `getEntityType` method)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 - Removed build with Java 8
+- Remove `Entity.entityType` field (deprecated `getEntityType` method)
 
 ## [9.2.0](https://github.com/dbmdz/digitalcollections-model/releases/tag/9.2.0) - 2022-04-06
 

--- a/dc-model-jackson/src/test/java/de/digitalcollections/model/jackson/identifiable/alias/UrlAliasTest.java
+++ b/dc-model-jackson/src/test/java/de/digitalcollections/model/jackson/identifiable/alias/UrlAliasTest.java
@@ -1,8 +1,8 @@
 package de.digitalcollections.model.jackson.identifiable.alias;
 
+import de.digitalcollections.model.identifiable.IdentifiableObjectType;
 import de.digitalcollections.model.identifiable.IdentifiableType;
 import de.digitalcollections.model.identifiable.alias.UrlAlias;
-import de.digitalcollections.model.identifiable.entity.EntityType;
 import de.digitalcollections.model.identifiable.entity.Website;
 import de.digitalcollections.model.jackson.BaseJsonSerializationTest;
 import java.time.LocalDateTime;
@@ -19,7 +19,7 @@ public class UrlAliasTest extends BaseJsonSerializationTest {
     urlAlias.setLastPublished(LocalDateTime.of(2021, Month.DECEMBER, 24, 12, 0, 0));
     urlAlias.setPrimary(true);
     urlAlias.setSlug("foobar");
-    urlAlias.setTargetEntityType(EntityType.COLLECTION);
+    urlAlias.setTargetIdentifiableObjectType(IdentifiableObjectType.COLLECTION);
     urlAlias.setTargetIdentifiableType(IdentifiableType.ENTITY);
     urlAlias.setTargetLanguage(Locale.GERMAN);
     urlAlias.setTargetUuid(UUID.fromString("c31593a4-9620-484b-a4f5-4112731d953b"));

--- a/dc-model-jackson/src/test/resources/serializedTestObjects/identifiable/alias/LocalizedUrlAliases.json
+++ b/dc-model-jackson/src/test/resources/serializedTestObjects/identifiable/alias/LocalizedUrlAliases.json
@@ -4,7 +4,7 @@
     "lastPublished" : "2021-12-24T12:00:00",
     "primary" : true,
     "slug" : "foobar",
-    "targetEntityType" : "COLLECTION",
+    "targetIdentifiableObjectType" : "COLLECTION",
     "targetIdentifiableType" : "ENTITY",
     "targetLanguage" : "de",
     "targetUuid" : "c31593a4-9620-484b-a4f5-4112731d953b",
@@ -14,8 +14,8 @@
       "identifiableObjectType" : "WEBSITE",
       "identifiers" : [ ],
       "type" : "ENTITY",
-      "entityType" : "WEBSITE",
-      "refId" : 0
+      "refId" : 0,
+      "entityType" : "WEBSITE"
     }
   } ]
 }

--- a/dc-model-jackson/src/test/resources/serializedTestObjects/identifiable/alias/UrlAlias.json
+++ b/dc-model-jackson/src/test/resources/serializedTestObjects/identifiable/alias/UrlAlias.json
@@ -3,7 +3,7 @@
   "lastPublished" : "2021-12-24T12:00:00",
   "primary" : true,
   "slug" : "foobar",
-  "targetEntityType" : "COLLECTION",
+  "targetIdentifiableObjectType" : "COLLECTION",
   "targetIdentifiableType" : "ENTITY",
   "targetLanguage" : "de",
   "targetUuid" : "c31593a4-9620-484b-a4f5-4112731d953b",
@@ -13,7 +13,7 @@
     "identifiableObjectType" : "WEBSITE",
     "identifiers" : [ ],
     "type" : "ENTITY",
-    "entityType" : "WEBSITE",
-    "refId" : 0
+    "refId" : 0,
+    "entityType" : "WEBSITE"
   }
 }

--- a/dc-model-jackson/src/test/resources/serializedTestObjects/identifiable/entity/Collection.json
+++ b/dc-model-jackson/src/test/resources/serializedTestObjects/identifiable/entity/Collection.json
@@ -14,8 +14,8 @@
   "identifiableObjectType" : "COLLECTION",
   "identifiers" : [ ],
   "type" : "ENTITY",
-  "entityType" : "COLLECTION",
   "refId" : 0,
   "publicationEnd" : "+999999999-12-31",
-  "publicationStart" : "-999999999-01-01"
+  "publicationStart" : "-999999999-01-01",
+  "entityType" : "COLLECTION"
 }

--- a/dc-model-jackson/src/test/resources/serializedTestObjects/identifiable/entity/DigitalObject.json
+++ b/dc-model-jackson/src/test/resources/serializedTestObjects/identifiable/entity/DigitalObject.json
@@ -18,7 +18,6 @@
   "customAttributes" : {
     "companySpecificAttributeX" : "foobar"
   },
-  "entityType" : "DIGITAL_OBJECT",
   "refId" : 0,
   "creationInfo" : {
     "creator" : {
@@ -28,10 +27,10 @@
         "" : "Creator"
       },
       "type" : "ENTITY",
-      "entityType" : "PERSON",
       "refId" : 0,
       "familyNames" : [ ],
-      "givenNames" : [ ]
+      "givenNames" : [ ],
+      "entityType" : "PERSON"
     },
     "date" : "2021-12-01",
     "geoLocation" : {
@@ -41,9 +40,9 @@
         "" : "Geolocation"
       },
       "type" : "ENTITY",
-      "entityType" : "GEOLOCATION",
       "refId" : 0,
-      "geoLocationType" : "HUMAN_SETTLEMENT"
+      "geoLocationType" : "HUMAN_SETTLEMENT",
+      "entityType" : "GEOLOCATION"
     }
   },
   "fileResources" : [ {
@@ -67,5 +66,6 @@
   } ],
   "linkedDataResources" : [ ],
   "numberOfBinaryResources" : 0,
-  "renderingResources" : [ ]
+  "renderingResources" : [ ],
+  "entityType" : "DIGITAL_OBJECT"
 }

--- a/dc-model-jackson/src/test/resources/serializedTestObjects/identifiable/entity/Entity.json
+++ b/dc-model-jackson/src/test/resources/serializedTestObjects/identifiable/entity/Entity.json
@@ -15,6 +15,6 @@
     "width" : 0
   },
   "type" : "ENTITY",
-  "entityType" : "ENTITY",
-  "refId" : 0
+  "refId" : 0,
+  "entityType" : "ENTITY"
 }

--- a/dc-model-jackson/src/test/resources/serializedTestObjects/identifiable/entity/HeadwordEntry.json
+++ b/dc-model-jackson/src/test/resources/serializedTestObjects/identifiable/entity/HeadwordEntry.json
@@ -2,11 +2,11 @@
   "identifiableObjectType" : "HEADWORD_ENTRY",
   "identifiers" : [ ],
   "type" : "ENTITY",
-  "entityType" : "HEADWORD_ENTRY",
   "refId" : 0,
   "creators" : [ ],
   "headword" : {
     "label" : "Kaiserschmarrn",
     "locale" : "de"
-  }
+  },
+  "entityType" : "HEADWORD_ENTRY"
 }

--- a/dc-model-jackson/src/test/resources/serializedTestObjects/identifiable/entity/Project.json
+++ b/dc-model-jackson/src/test/resources/serializedTestObjects/identifiable/entity/Project.json
@@ -5,7 +5,7 @@
     "de" : "Projekt XY"
   },
   "type" : "ENTITY",
-  "entityType" : "PROJECT",
   "refId" : 0,
-  "startDate" : "2019-07-31"
+  "startDate" : "2019-07-31",
+  "entityType" : "PROJECT"
 }

--- a/dc-model-jackson/src/test/resources/serializedTestObjects/identifiable/entity/Topic.json
+++ b/dc-model-jackson/src/test/resources/serializedTestObjects/identifiable/entity/Topic.json
@@ -17,7 +17,6 @@
     "en" : "King Ludwig II of Bavaria and his Times"
   },
   "type" : "ENTITY",
-  "entityType" : "TOPIC",
   "refId" : 0,
   "children" : [ {
     "description" : {
@@ -38,8 +37,8 @@
       "en" : "Sources about the Life and Times of Ludwig II"
     },
     "type" : "ENTITY",
-    "entityType" : "TOPIC",
-    "refId" : 0
+    "refId" : 0,
+    "entityType" : "TOPIC"
   }, {
     "description" : {
       "en" : {
@@ -59,8 +58,8 @@
       "en" : "Artistic Influences and Models"
     },
     "type" : "ENTITY",
-    "entityType" : "TOPIC",
-    "refId" : 0
+    "refId" : 0,
+    "entityType" : "TOPIC"
   }, {
     "description" : {
       "en" : {
@@ -80,8 +79,8 @@
       "en" : "Castles and Constructions of Ludwig II"
     },
     "type" : "ENTITY",
-    "entityType" : "TOPIC",
-    "refId" : 0
+    "refId" : 0,
+    "entityType" : "TOPIC"
   }, {
     "description" : {
       "en" : {
@@ -101,7 +100,8 @@
       "en" : "Ludwig II and the Bayerische Staatsbibliothek"
     },
     "type" : "ENTITY",
-    "entityType" : "TOPIC",
-    "refId" : 0
-  } ]
+    "refId" : 0,
+    "entityType" : "TOPIC"
+  } ],
+  "entityType" : "TOPIC"
 }

--- a/dc-model-jackson/src/test/resources/serializedTestObjects/identifiable/entity/Website.json
+++ b/dc-model-jackson/src/test/resources/serializedTestObjects/identifiable/entity/Website.json
@@ -14,7 +14,7 @@
   "identifiableObjectType" : "WEBSITE",
   "identifiers" : [ ],
   "type" : "ENTITY",
-  "entityType" : "WEBSITE",
   "refId" : 0,
-  "url" : "http://www.example.org/"
+  "url" : "http://www.example.org/",
+  "entityType" : "WEBSITE"
 }

--- a/dc-model-jackson/src/test/resources/serializedTestObjects/identifiable/entity/agent/CorporateBody.json
+++ b/dc-model-jackson/src/test/resources/serializedTestObjects/identifiable/entity/agent/CorporateBody.json
@@ -5,6 +5,6 @@
     "de" : "Bayerische Staatsbibliothek"
   },
   "type" : "ENTITY",
-  "entityType" : "CORPORATE_BODY",
-  "refId" : 0
+  "refId" : 0,
+  "entityType" : "CORPORATE_BODY"
 }

--- a/dc-model-jackson/src/test/resources/serializedTestObjects/identifiable/entity/geo/location/Canyon.json
+++ b/dc-model-jackson/src/test/resources/serializedTestObjects/identifiable/entity/geo/location/Canyon.json
@@ -5,7 +5,6 @@
     "en" : "Canyon"
   },
   "type" : "ENTITY",
-  "entityType" : "GEOLOCATION",
   "refId" : 0,
   "coordinateLocation" : {
     "altitude" : 0.0,
@@ -13,5 +12,6 @@
     "longitude" : 11.52559973769878,
     "precision" : 6.0
   },
-  "geoLocationType" : "CANYON"
+  "geoLocationType" : "CANYON",
+  "entityType" : "GEOLOCATION"
 }

--- a/dc-model-jackson/src/test/resources/serializedTestObjects/identifiable/entity/geo/location/Cave.json
+++ b/dc-model-jackson/src/test/resources/serializedTestObjects/identifiable/entity/geo/location/Cave.json
@@ -5,7 +5,6 @@
     "en" : "Cave"
   },
   "type" : "ENTITY",
-  "entityType" : "GEOLOCATION",
   "refId" : 0,
   "coordinateLocation" : {
     "altitude" : 0.0,
@@ -13,5 +12,6 @@
     "longitude" : 11.52559973769878,
     "precision" : 6.0
   },
-  "geoLocationType" : "CAVE"
+  "geoLocationType" : "CAVE",
+  "entityType" : "GEOLOCATION"
 }

--- a/dc-model-jackson/src/test/resources/serializedTestObjects/identifiable/entity/geo/location/Continent.json
+++ b/dc-model-jackson/src/test/resources/serializedTestObjects/identifiable/entity/geo/location/Continent.json
@@ -5,7 +5,6 @@
     "en" : "Continent"
   },
   "type" : "ENTITY",
-  "entityType" : "GEOLOCATION",
   "refId" : 0,
   "coordinateLocation" : {
     "altitude" : 0.0,
@@ -13,5 +12,6 @@
     "longitude" : 11.52559973769878,
     "precision" : 6.0
   },
-  "geoLocationType" : "CONTINENT"
+  "geoLocationType" : "CONTINENT",
+  "entityType" : "GEOLOCATION"
 }

--- a/dc-model-jackson/src/test/resources/serializedTestObjects/identifiable/entity/geo/location/Country.json
+++ b/dc-model-jackson/src/test/resources/serializedTestObjects/identifiable/entity/geo/location/Country.json
@@ -5,7 +5,6 @@
     "en" : "Country"
   },
   "type" : "ENTITY",
-  "entityType" : "GEOLOCATION",
   "refId" : 0,
   "coordinateLocation" : {
     "altitude" : 0.0,
@@ -13,5 +12,6 @@
     "longitude" : 11.52559973769878,
     "precision" : 6.0
   },
-  "geoLocationType" : "COUNTRY"
+  "geoLocationType" : "COUNTRY",
+  "entityType" : "GEOLOCATION"
 }

--- a/dc-model-jackson/src/test/resources/serializedTestObjects/identifiable/entity/geo/location/Creek.json
+++ b/dc-model-jackson/src/test/resources/serializedTestObjects/identifiable/entity/geo/location/Creek.json
@@ -5,7 +5,6 @@
     "en" : "Creek"
   },
   "type" : "ENTITY",
-  "entityType" : "GEOLOCATION",
   "refId" : 0,
   "coordinateLocation" : {
     "altitude" : 0.0,
@@ -13,5 +12,6 @@
     "longitude" : 11.52559973769878,
     "precision" : 6.0
   },
-  "geoLocationType" : "CREEK"
+  "geoLocationType" : "CREEK",
+  "entityType" : "GEOLOCATION"
 }

--- a/dc-model-jackson/src/test/resources/serializedTestObjects/identifiable/entity/geo/location/GeoLocation.json
+++ b/dc-model-jackson/src/test/resources/serializedTestObjects/identifiable/entity/geo/location/GeoLocation.json
@@ -5,7 +5,6 @@
     "de" : "Homebase"
   },
   "type" : "ENTITY",
-  "entityType" : "GEOLOCATION",
   "refId" : 0,
   "coordinateLocation" : {
     "altitude" : 0.0,
@@ -13,5 +12,6 @@
     "longitude" : 11.52559973769878,
     "precision" : 6.0
   },
-  "geoLocationType" : "GEOLOCATION"
+  "geoLocationType" : "GEOLOCATION",
+  "entityType" : "GEOLOCATION"
 }

--- a/dc-model-jackson/src/test/resources/serializedTestObjects/identifiable/entity/geo/location/HumanSettlement.json
+++ b/dc-model-jackson/src/test/resources/serializedTestObjects/identifiable/entity/geo/location/HumanSettlement.json
@@ -5,7 +5,6 @@
     "en" : "Human Settlement"
   },
   "type" : "ENTITY",
-  "entityType" : "GEOLOCATION",
   "refId" : 0,
   "coordinateLocation" : {
     "altitude" : 0.0,
@@ -13,5 +12,6 @@
     "longitude" : 11.52559973769878,
     "precision" : 6.0
   },
-  "geoLocationType" : "HUMAN_SETTLEMENT"
+  "geoLocationType" : "HUMAN_SETTLEMENT",
+  "entityType" : "GEOLOCATION"
 }

--- a/dc-model-jackson/src/test/resources/serializedTestObjects/identifiable/entity/geo/location/Lake.json
+++ b/dc-model-jackson/src/test/resources/serializedTestObjects/identifiable/entity/geo/location/Lake.json
@@ -5,7 +5,6 @@
     "en" : "Lake"
   },
   "type" : "ENTITY",
-  "entityType" : "GEOLOCATION",
   "refId" : 0,
   "coordinateLocation" : {
     "altitude" : 0.0,
@@ -13,5 +12,6 @@
     "longitude" : 11.52559973769878,
     "precision" : 6.0
   },
-  "geoLocationType" : "LAKE"
+  "geoLocationType" : "LAKE",
+  "entityType" : "GEOLOCATION"
 }

--- a/dc-model-jackson/src/test/resources/serializedTestObjects/identifiable/entity/geo/location/Mountain.json
+++ b/dc-model-jackson/src/test/resources/serializedTestObjects/identifiable/entity/geo/location/Mountain.json
@@ -8,7 +8,6 @@
   "customAttributes" : {
     "height" : 8999
   },
-  "entityType" : "GEOLOCATION",
   "refId" : 0,
   "coordinateLocation" : {
     "altitude" : 0.0,
@@ -16,5 +15,6 @@
     "longitude" : 11.52559973769878,
     "precision" : 6.0
   },
-  "geoLocationType" : "MOUNTAIN"
+  "geoLocationType" : "MOUNTAIN",
+  "entityType" : "GEOLOCATION"
 }

--- a/dc-model-jackson/src/test/resources/serializedTestObjects/identifiable/entity/geo/location/Ocean.json
+++ b/dc-model-jackson/src/test/resources/serializedTestObjects/identifiable/entity/geo/location/Ocean.json
@@ -5,7 +5,6 @@
     "en" : "Ocean"
   },
   "type" : "ENTITY",
-  "entityType" : "GEOLOCATION",
   "refId" : 0,
   "coordinateLocation" : {
     "altitude" : 0.0,
@@ -13,5 +12,6 @@
     "longitude" : 11.52559973769878,
     "precision" : 6.0
   },
-  "geoLocationType" : "OCEAN"
+  "geoLocationType" : "OCEAN",
+  "entityType" : "GEOLOCATION"
 }

--- a/dc-model-jackson/src/test/resources/serializedTestObjects/identifiable/entity/geo/location/River.json
+++ b/dc-model-jackson/src/test/resources/serializedTestObjects/identifiable/entity/geo/location/River.json
@@ -5,7 +5,6 @@
     "en" : "River"
   },
   "type" : "ENTITY",
-  "entityType" : "GEOLOCATION",
   "refId" : 0,
   "coordinateLocation" : {
     "altitude" : 0.0,
@@ -13,5 +12,6 @@
     "longitude" : 11.52559973769878,
     "precision" : 6.0
   },
-  "geoLocationType" : "RIVER"
+  "geoLocationType" : "RIVER",
+  "entityType" : "GEOLOCATION"
 }

--- a/dc-model-jackson/src/test/resources/serializedTestObjects/identifiable/entity/geo/location/Sea.json
+++ b/dc-model-jackson/src/test/resources/serializedTestObjects/identifiable/entity/geo/location/Sea.json
@@ -5,7 +5,6 @@
     "en" : "Sea"
   },
   "type" : "ENTITY",
-  "entityType" : "GEOLOCATION",
   "refId" : 0,
   "coordinateLocation" : {
     "altitude" : 0.0,
@@ -13,5 +12,6 @@
     "longitude" : 11.52559973769878,
     "precision" : 6.0
   },
-  "geoLocationType" : "SEA"
+  "geoLocationType" : "SEA",
+  "entityType" : "GEOLOCATION"
 }

--- a/dc-model-jackson/src/test/resources/serializedTestObjects/identifiable/entity/geo/location/StillWaters.json
+++ b/dc-model-jackson/src/test/resources/serializedTestObjects/identifiable/entity/geo/location/StillWaters.json
@@ -5,7 +5,6 @@
     "en" : "Still Waters"
   },
   "type" : "ENTITY",
-  "entityType" : "GEOLOCATION",
   "refId" : 0,
   "coordinateLocation" : {
     "altitude" : 0.0,
@@ -13,5 +12,6 @@
     "longitude" : 11.52559973769878,
     "precision" : 6.0
   },
-  "geoLocationType" : "STILL_WATERS"
+  "geoLocationType" : "STILL_WATERS",
+  "entityType" : "GEOLOCATION"
 }

--- a/dc-model-jackson/src/test/resources/serializedTestObjects/identifiable/entity/geo/location/Valley.json
+++ b/dc-model-jackson/src/test/resources/serializedTestObjects/identifiable/entity/geo/location/Valley.json
@@ -5,7 +5,6 @@
     "en" : "Valley"
   },
   "type" : "ENTITY",
-  "entityType" : "GEOLOCATION",
   "refId" : 0,
   "coordinateLocation" : {
     "altitude" : 0.0,
@@ -13,5 +12,6 @@
     "longitude" : 11.52559973769878,
     "precision" : 6.0
   },
-  "geoLocationType" : "VALLEY"
+  "geoLocationType" : "VALLEY",
+  "entityType" : "GEOLOCATION"
 }

--- a/dc-model-jackson/src/test/resources/serializedTestObjects/identifiable/entity/relation/EntityRelation.json
+++ b/dc-model-jackson/src/test/resources/serializedTestObjects/identifiable/entity/relation/EntityRelation.json
@@ -4,12 +4,12 @@
     "identifiableObjectType" : "DIGITAL_OBJECT",
     "identifiers" : [ ],
     "type" : "ENTITY",
-    "entityType" : "DIGITAL_OBJECT",
     "refId" : 0,
     "fileResources" : [ ],
     "linkedDataResources" : [ ],
     "numberOfBinaryResources" : 0,
-    "renderingResources" : [ ]
+    "renderingResources" : [ ],
+    "entityType" : "DIGITAL_OBJECT"
   },
   "predicate" : "is_describing_provenience",
   "subject" : {
@@ -17,8 +17,8 @@
     "identifiableObjectType" : "ARTICLE",
     "identifiers" : [ ],
     "type" : "ENTITY",
-    "entityType" : "ARTICLE",
     "refId" : 0,
-    "creators" : [ ]
+    "creators" : [ ],
+    "entityType" : "ARTICLE"
   }
 }

--- a/dc-model-jackson/src/test/resources/serializedTestObjects/identifiable/entity/work/Item.json
+++ b/dc-model-jackson/src/test/resources/serializedTestObjects/identifiable/entity/work/Item.json
@@ -16,11 +16,11 @@
     "width" : 0
   },
   "type" : "ENTITY",
-  "entityType" : "ITEM",
   "refId" : 0,
   "language" : "de",
   "publicationDate" : "1912",
   "publicationPlace" : "Leipzig",
   "publisher" : "Thieme",
-  "version" : "Zweite Auflage"
+  "version" : "Zweite Auflage",
+  "entityType" : "ITEM"
 }

--- a/dc-model-jackson/src/test/resources/serializedTestObjects/identifiable/entity/work/Work.json
+++ b/dc-model-jackson/src/test/resources/serializedTestObjects/identifiable/entity/work/Work.json
@@ -5,7 +5,6 @@
     "de" : "Zimmer-Gymnastik ohne Geräte"
   },
   "type" : "ENTITY",
-  "entityType" : "WORK",
   "refId" : 0,
   "creators" : [ {
     "identifiableObjectType" : "PERSON",
@@ -14,10 +13,10 @@
       "de" : "Arnold Hiller"
     },
     "type" : "ENTITY",
-    "entityType" : "PERSON",
     "refId" : 0,
     "familyNames" : [ ],
-    "givenNames" : [ ]
+    "givenNames" : [ ],
+    "entityType" : "PERSON"
   } ],
   "datePublished" : "2020-04-28",
   "timeValuePublished" : {
@@ -32,5 +31,6 @@
     "second" : 0,
     "timezoneOffset" : 0,
     "year" : 2020
-  }
+  },
+  "entityType" : "WORK"
 }

--- a/dc-model-jackson/src/test/resources/serializedTestObjects/list/paging/PageResponse_differentTypes.json
+++ b/dc-model-jackson/src/test/resources/serializedTestObjects/list/paging/PageResponse_differentTypes.json
@@ -7,12 +7,12 @@
       "" : "DigitalObject-Label"
     },
     "type" : "ENTITY",
-    "entityType" : "DIGITAL_OBJECT",
     "refId" : 0,
     "fileResources" : [ ],
     "linkedDataResources" : [ ],
     "numberOfBinaryResources" : 0,
-    "renderingResources" : [ ]
+    "renderingResources" : [ ],
+    "entityType" : "DIGITAL_OBJECT"
   }, {
     "objectType" : "WEBPAGE",
     "identifiableObjectType" : "WEBPAGE",

--- a/dc-model/src/main/java/de/digitalcollections/model/identifiable/alias/LocalizedUrlAliases.java
+++ b/dc-model/src/main/java/de/digitalcollections/model/identifiable/alias/LocalizedUrlAliases.java
@@ -27,7 +27,7 @@ public class LocalizedUrlAliases extends HashMap<Locale, List<UrlAlias>> {
       return;
     }
     for (UrlAlias urlAlias : urlAliases) {
-      if (urlAlias==null) {
+      if (urlAlias == null) {
         continue;
       }
       this.compute(

--- a/dc-model/src/main/java/de/digitalcollections/model/identifiable/alias/LocalizedUrlAliases.java
+++ b/dc-model/src/main/java/de/digitalcollections/model/identifiable/alias/LocalizedUrlAliases.java
@@ -27,6 +27,9 @@ public class LocalizedUrlAliases extends HashMap<Locale, List<UrlAlias>> {
       return;
     }
     for (UrlAlias urlAlias : urlAliases) {
+      if (urlAlias==null) {
+        continue;
+      }
       this.compute(
           urlAlias.getTargetLanguage(),
           (locale, listOfAliases) -> {

--- a/dc-model/src/main/java/de/digitalcollections/model/identifiable/alias/UrlAlias.java
+++ b/dc-model/src/main/java/de/digitalcollections/model/identifiable/alias/UrlAlias.java
@@ -70,6 +70,7 @@ public class UrlAlias {
     return this.slug;
   }
 
+  @Deprecated(forRemoval = true, since = "10.0.0")
   public EntityType getTargetEntityType() {
     return this.targetEntityType;
   }
@@ -108,7 +109,6 @@ public class UrlAlias {
         this.targetLanguage,
         this.targetIdentifiableObjectType,
         this.targetIdentifiableType,
-        this.targetEntityType,
         this.targetUuid,
         this.uuid,
         this.website);
@@ -134,6 +134,7 @@ public class UrlAlias {
     this.slug = slug;
   }
 
+  @Deprecated(forRemoval = true, since = "10.0.0")
   public void setTargetEntityType(EntityType targetEntityType) {
     this.targetEntityType = targetEntityType;
   }

--- a/dc-model/src/main/java/de/digitalcollections/model/identifiable/alias/UrlAlias.java
+++ b/dc-model/src/main/java/de/digitalcollections/model/identifiable/alias/UrlAlias.java
@@ -166,17 +166,29 @@ public class UrlAlias {
   @Override
   public String toString() {
     return "UrlAlias{"
-        + "created=" + created
-        + ", lastPublished=" + lastPublished
-        + ", primary=" + primary
-        + ", slug='" + slug + '\''
-        + ", targetEntityType=" + targetEntityType
-        + ", targetIdentifiableObjectType=" + targetIdentifiableObjectType
-        + ", targetIdentifiableType=" + targetIdentifiableType
-        + ", targetLanguage=" + targetLanguage
-        + ", targetUuid=" + targetUuid
-        + ", uuid=" + uuid
-        + ", website=" + website
+        + "created="
+        + created
+        + ", lastPublished="
+        + lastPublished
+        + ", primary="
+        + primary
+        + ", slug='"
+        + slug
+        + '\''
+        + ", targetEntityType="
+        + targetEntityType
+        + ", targetIdentifiableObjectType="
+        + targetIdentifiableObjectType
+        + ", targetIdentifiableType="
+        + targetIdentifiableType
+        + ", targetLanguage="
+        + targetLanguage
+        + ", targetUuid="
+        + targetUuid
+        + ", uuid="
+        + uuid
+        + ", website="
+        + website
         + '}';
   }
 

--- a/dc-model/src/main/java/de/digitalcollections/model/identifiable/alias/UrlAlias.java
+++ b/dc-model/src/main/java/de/digitalcollections/model/identifiable/alias/UrlAlias.java
@@ -163,6 +163,23 @@ public class UrlAlias {
     this.website = website;
   }
 
+  @Override
+  public String toString() {
+    return "UrlAlias{"
+        + "created=" + created
+        + ", lastPublished=" + lastPublished
+        + ", primary=" + primary
+        + ", slug='" + slug + '\''
+        + ", targetEntityType=" + targetEntityType
+        + ", targetIdentifiableObjectType=" + targetIdentifiableObjectType
+        + ", targetIdentifiableType=" + targetIdentifiableType
+        + ", targetLanguage=" + targetLanguage
+        + ", targetUuid=" + targetUuid
+        + ", uuid=" + uuid
+        + ", website=" + website
+        + '}';
+  }
+
   public static class Builder {
 
     UrlAlias urlAlias = new UrlAlias();

--- a/dc-model/src/main/java/de/digitalcollections/model/identifiable/entity/Article.java
+++ b/dc-model/src/main/java/de/digitalcollections/model/identifiable/entity/Article.java
@@ -41,7 +41,6 @@ public class Article extends Entity {
   @Override
   protected void init() {
     super.init();
-    this.entityType = EntityType.ARTICLE;
     if (creators == null) {
       creators = new ArrayList<>(0);
     }

--- a/dc-model/src/main/java/de/digitalcollections/model/identifiable/entity/Collection.java
+++ b/dc-model/src/main/java/de/digitalcollections/model/identifiable/entity/Collection.java
@@ -88,7 +88,6 @@ public class Collection extends Entity implements INode<Collection> {
   @Override
   protected void init() {
     super.init();
-    this.entityType = EntityType.COLLECTION;
     if (node == null) {
       node = new Node<>();
     }
@@ -135,8 +134,6 @@ public class Collection extends Entity implements INode<Collection> {
         + text
         + ", customAttributes="
         + customAttributes
-        + ", entityType="
-        + entityType
         + ", refId="
         + refId
         + ", created="

--- a/dc-model/src/main/java/de/digitalcollections/model/identifiable/entity/DigitalObject.java
+++ b/dc-model/src/main/java/de/digitalcollections/model/identifiable/entity/DigitalObject.java
@@ -131,7 +131,6 @@ public class DigitalObject extends Entity {
   @Override
   protected void init() {
     super.init();
-    this.entityType = EntityType.DIGITAL_OBJECT;
     if (fileResources == null) {
       fileResources = new ArrayList<>(0);
     }

--- a/dc-model/src/main/java/de/digitalcollections/model/identifiable/entity/Entity.java
+++ b/dc-model/src/main/java/de/digitalcollections/model/identifiable/entity/Entity.java
@@ -23,7 +23,6 @@ import lombok.experimental.SuperBuilder;
 public class Entity extends Identifiable {
 
   protected CustomAttributes customAttributes;
-  protected EntityType entityType;
   /** A "navigable" date, required when you need to the display the digital object on a timeline. */
   protected LocalDate navDate;
 
@@ -46,9 +45,7 @@ public class Entity extends Identifiable {
       return false;
     }
     Entity entity = (Entity) o;
-    return refId == entity.refId
-        && Objects.equals(customAttributes, entity.customAttributes)
-        && entityType == entity.entityType;
+    return refId == entity.refId && Objects.equals(customAttributes, entity.customAttributes);
   }
 
   /**
@@ -70,11 +67,37 @@ public class Entity extends Identifiable {
   }
 
   /**
+   * @deprecated Use {@link Identifiable#getType()} and {@link
+   *     Identifiable#getIdentifiableObjectType()} instead.
    * @return the type of the entity (one of the types this system can manage, defined in enum
    *     EntityType).
    */
+  @Deprecated(forRemoval = true, since = "10.0.0")
   public EntityType getEntityType() {
-    return entityType;
+    if (IdentifiableType.RESOURCE == getType()) {
+      return null;
+    }
+    switch (identifiableObjectType) {
+      case CANYON:
+      case CAVE:
+      case CONTINENT:
+      case COUNTRY:
+      case CREEK:
+      case GEO_LOCATION:
+      case HUMAN_SETTLEMENT:
+      case LAKE:
+      case MOUNTAIN:
+      case OCEAN:
+      case RIVER:
+      case SEA:
+      case STILL_WATERS:
+      case VALLEY:
+        return EntityType.GEOLOCATION;
+      default:
+        // as both enum have String identical enum values in all other cases, we can simply map by
+        // String:
+        return EntityType.valueOf(getIdentifiableObjectType().toString());
+    }
   }
 
   /**
@@ -104,13 +127,12 @@ public class Entity extends Identifiable {
 
   @Override
   public int hashCode() {
-    return Objects.hash(super.hashCode(), customAttributes, entityType, refId);
+    return Objects.hash(super.hashCode(), customAttributes, refId);
   }
 
   @Override
   protected void init() {
     super.init();
-    this.entityType = EntityType.ENTITY;
     this.type = IdentifiableType.ENTITY;
   }
 
@@ -134,13 +156,6 @@ public class Entity extends Identifiable {
    */
   public void setCustomAttributes(CustomAttributes customAttributes) {
     this.customAttributes = customAttributes;
-  }
-
-  /**
-   * @param entityType the type of the entity
-   */
-  public void setEntityType(EntityType entityType) {
-    this.entityType = entityType;
   }
 
   /**

--- a/dc-model/src/main/java/de/digitalcollections/model/identifiable/entity/EntityType.java
+++ b/dc-model/src/main/java/de/digitalcollections/model/identifiable/entity/EntityType.java
@@ -1,6 +1,11 @@
 package de.digitalcollections.model.identifiable.entity;
 
-/** All entity types cudami can handle */
+/**
+ * All entity types cudami can handle
+ *
+ * @deprecated Use IdentifiableObjectType instead.
+ */
+@Deprecated(forRemoval = true, since = "10.0.0")
 public enum EntityType {
   AGENT,
   ARTICLE,

--- a/dc-model/src/main/java/de/digitalcollections/model/identifiable/entity/HeadwordEntry.java
+++ b/dc-model/src/main/java/de/digitalcollections/model/identifiable/entity/HeadwordEntry.java
@@ -37,7 +37,6 @@ public class HeadwordEntry extends Article {
   @Override
   protected void init() {
     super.init();
-    this.entityType = EntityType.HEADWORD_ENTRY;
   }
 
   public void setHeadword(Headword headword) {

--- a/dc-model/src/main/java/de/digitalcollections/model/identifiable/entity/Project.java
+++ b/dc-model/src/main/java/de/digitalcollections/model/identifiable/entity/Project.java
@@ -44,7 +44,6 @@ public class Project extends Entity {
   @Override
   protected void init() {
     super.init();
-    this.entityType = EntityType.PROJECT;
   }
 
   /**

--- a/dc-model/src/main/java/de/digitalcollections/model/identifiable/entity/Topic.java
+++ b/dc-model/src/main/java/de/digitalcollections/model/identifiable/entity/Topic.java
@@ -76,7 +76,6 @@ public class Topic extends Entity implements INode<Topic> {
   @Override
   protected void init() {
     super.init();
-    this.entityType = EntityType.TOPIC;
     if (node == null) {
       node = new Node<>();
     }

--- a/dc-model/src/main/java/de/digitalcollections/model/identifiable/entity/Website.java
+++ b/dc-model/src/main/java/de/digitalcollections/model/identifiable/entity/Website.java
@@ -46,7 +46,6 @@ public class Website extends Entity {
   @Override
   protected void init() {
     super.init();
-    this.entityType = EntityType.WEBSITE;
   }
 
   public void setRegistrationDate(LocalDate registrationDate) {

--- a/dc-model/src/main/java/de/digitalcollections/model/identifiable/entity/agent/Agent.java
+++ b/dc-model/src/main/java/de/digitalcollections/model/identifiable/entity/agent/Agent.java
@@ -1,7 +1,6 @@
 package de.digitalcollections.model.identifiable.entity.agent;
 
 import de.digitalcollections.model.identifiable.entity.Entity;
-import de.digitalcollections.model.identifiable.entity.EntityType;
 import lombok.experimental.SuperBuilder;
 
 /**
@@ -23,7 +22,6 @@ public class Agent extends Entity {
   @Override
   protected void init() {
     super.init();
-    this.entityType = EntityType.AGENT;
   }
 
   @Override
@@ -51,8 +49,6 @@ public class Agent extends Entity {
         + type
         + ", customAttributes="
         + customAttributes
-        + ", entityType="
-        + entityType
         + ", navDate="
         + navDate
         + ", refId="

--- a/dc-model/src/main/java/de/digitalcollections/model/identifiable/entity/agent/CorporateBody.java
+++ b/dc-model/src/main/java/de/digitalcollections/model/identifiable/entity/agent/CorporateBody.java
@@ -1,6 +1,5 @@
 package de.digitalcollections.model.identifiable.entity.agent;
 
-import de.digitalcollections.model.identifiable.entity.EntityType;
 import de.digitalcollections.model.text.LocalizedStructuredContent;
 import de.digitalcollections.model.text.StructuredContent;
 import de.digitalcollections.model.text.contentblock.ContentBlock;
@@ -66,7 +65,6 @@ public class CorporateBody extends Agent {
   @Override
   protected void init() {
     super.init();
-    this.entityType = EntityType.CORPORATE_BODY;
   }
 
   /**
@@ -108,8 +106,6 @@ public class CorporateBody extends Agent {
         + type
         + ", customAttributes="
         + customAttributes
-        + ", entityType="
-        + entityType
         + ", navDate="
         + navDate
         + ", refId="

--- a/dc-model/src/main/java/de/digitalcollections/model/identifiable/entity/agent/Family.java
+++ b/dc-model/src/main/java/de/digitalcollections/model/identifiable/entity/agent/Family.java
@@ -1,6 +1,5 @@
 package de.digitalcollections.model.identifiable.entity.agent;
 
-import de.digitalcollections.model.identifiable.entity.EntityType;
 import lombok.experimental.SuperBuilder;
 
 /** A family (e.g. the "Clintons"). */
@@ -15,7 +14,6 @@ public class Family extends Agent {
   @Override
   protected void init() {
     super.init();
-    this.entityType = EntityType.FAMILY;
   }
 
   public abstract static class FamilyBuilder<C extends Family, B extends FamilyBuilder<C, B>>

--- a/dc-model/src/main/java/de/digitalcollections/model/identifiable/entity/agent/Person.java
+++ b/dc-model/src/main/java/de/digitalcollections/model/identifiable/entity/agent/Person.java
@@ -3,7 +3,6 @@ package de.digitalcollections.model.identifiable.entity.agent;
 import de.digitalcollections.model.identifiable.Identifier;
 import de.digitalcollections.model.identifiable.agent.FamilyName;
 import de.digitalcollections.model.identifiable.agent.GivenName;
-import de.digitalcollections.model.identifiable.entity.EntityType;
 import de.digitalcollections.model.identifiable.entity.geo.location.GeoLocation;
 import de.digitalcollections.model.text.LocalizedText;
 import java.time.LocalDate;
@@ -81,7 +80,6 @@ public class Person extends Agent {
   @Override
   protected void init() {
     super.init();
-    this.entityType = EntityType.PERSON;
     if (familyNames == null) {
       familyNames = new ArrayList<>(0);
     }

--- a/dc-model/src/main/java/de/digitalcollections/model/identifiable/entity/geo/location/GeoLocation.java
+++ b/dc-model/src/main/java/de/digitalcollections/model/identifiable/entity/geo/location/GeoLocation.java
@@ -2,7 +2,6 @@ package de.digitalcollections.model.identifiable.entity.geo.location;
 
 import de.digitalcollections.model.geo.CoordinateLocation;
 import de.digitalcollections.model.identifiable.entity.Entity;
-import de.digitalcollections.model.identifiable.entity.EntityType;
 import lombok.experimental.SuperBuilder;
 
 /** A location located on earth. */
@@ -42,7 +41,6 @@ public class GeoLocation extends Entity {
   @Override
   protected void init() {
     super.init();
-    this.entityType = EntityType.GEOLOCATION;
     this.geoLocationType = GeoLocationType.GEOLOCATION;
   }
 

--- a/dc-model/src/main/java/de/digitalcollections/model/identifiable/entity/work/Expression.java
+++ b/dc-model/src/main/java/de/digitalcollections/model/identifiable/entity/work/Expression.java
@@ -1,7 +1,6 @@
 package de.digitalcollections.model.identifiable.entity.work;
 
 import de.digitalcollections.model.identifiable.entity.Entity;
-import de.digitalcollections.model.identifiable.entity.EntityType;
 
 /**
  * From https://web.library.yale.edu/cataloging/music/frbr-wemi-music#work:
@@ -56,6 +55,5 @@ public class Expression extends Entity {
   @Override
   protected void init() {
     super.init();
-    this.entityType = EntityType.EXPRESSION;
   }
 }

--- a/dc-model/src/main/java/de/digitalcollections/model/identifiable/entity/work/Item.java
+++ b/dc-model/src/main/java/de/digitalcollections/model/identifiable/entity/work/Item.java
@@ -1,7 +1,6 @@
 package de.digitalcollections.model.identifiable.entity.work;
 
 import de.digitalcollections.model.identifiable.entity.Entity;
-import de.digitalcollections.model.identifiable.entity.EntityType;
 import de.digitalcollections.model.text.LocalizedText;
 import java.util.Locale;
 import lombok.experimental.SuperBuilder;
@@ -82,7 +81,6 @@ public class Item extends Entity {
   @Override
   protected void init() {
     super.init();
-    this.entityType = EntityType.ITEM;
   }
 
   /**
@@ -166,8 +164,6 @@ public class Item extends Entity {
         + publisher
         + "', version='"
         + version
-        + "', entityType="
-        + entityType
         + ", refId="
         + refId
         + ", created="

--- a/dc-model/src/main/java/de/digitalcollections/model/identifiable/entity/work/Manifestation.java
+++ b/dc-model/src/main/java/de/digitalcollections/model/identifiable/entity/work/Manifestation.java
@@ -1,7 +1,6 @@
 package de.digitalcollections.model.identifiable.entity.work;
 
 import de.digitalcollections.model.identifiable.entity.Entity;
-import de.digitalcollections.model.identifiable.entity.EntityType;
 
 /**
  * From https://web.library.yale.edu/cataloging/music/frbr-wemi-music#work:
@@ -33,6 +32,5 @@ public class Manifestation extends Entity {
   @Override
   protected void init() {
     super.init();
-    this.entityType = EntityType.MANIFESTATION;
   }
 }

--- a/dc-model/src/main/java/de/digitalcollections/model/identifiable/entity/work/Work.java
+++ b/dc-model/src/main/java/de/digitalcollections/model/identifiable/entity/work/Work.java
@@ -1,7 +1,6 @@
 package de.digitalcollections.model.identifiable.entity.work;
 
 import de.digitalcollections.model.identifiable.entity.Entity;
-import de.digitalcollections.model.identifiable.entity.EntityType;
 import de.digitalcollections.model.identifiable.entity.agent.Agent;
 import de.digitalcollections.model.text.LocalizedText;
 import java.time.LocalDate;
@@ -61,7 +60,6 @@ public class Work extends Entity {
   @Override
   protected void init() {
     super.init();
-    this.entityType = EntityType.WORK;
     if (creators == null) {
       this.creators = new ArrayList<>(0);
     }

--- a/dc-model/src/test/java/de/digitalcollections/model/identifiable/entity/DigitalObjectTest.java
+++ b/dc-model/src/test/java/de/digitalcollections/model/identifiable/entity/DigitalObjectTest.java
@@ -28,7 +28,6 @@ class DigitalObjectTest {
             .build();
     assertThat(digitalObject).isExactlyInstanceOf(DigitalObject.class);
     assertThat(digitalObject.getType()).isEqualTo(IdentifiableType.ENTITY);
-    assertThat(digitalObject.getEntityType()).isEqualTo(EntityType.DIGITAL_OBJECT);
     assertThat(digitalObject.getIdentifiableObjectType())
         .isEqualTo(IdentifiableObjectType.DIGITAL_OBJECT);
   }


### PR DESCRIPTION
Remove no longer needed field "entityType" from all entities.