### PR TITLE
Mapping module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 /dc-model/nbproject/
 /nb-configuration.xml
 /dc-model-xml/nbproject/
+/dc-model-mappings/dc-model-html-mapping/nbproject/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add field `tags` to `Identifiable`
 - Bucket-Handling: Bucket (Sublist/Range of UniqueObjects), BucketRequest/Response and List of Bucket-Objects-Handling added
 - **Breaking**: Jackson-MixIns (type info `objectType`) for classes directly extending `UniqueObject` (`Headword, Identifiable, Identifier, IdentifierType, License, Predicate, RenderingTemplate, User`)
+- Add submodule "mappings" with submodule "html" for mapping HTML code (currently supporting ul, li, a) to DC-Model StructuredContent
+- Add convenience method addLocalizedUrlAlias(UrlAlias urlAlias) to Identifiable
 
 ### Changed
 

--- a/dc-model-mappings/dc-model-html-mapping/pom.xml
+++ b/dc-model-mappings/dc-model-html-mapping/pom.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>de.digitalcollections.model</groupId>
+        <artifactId>dc-model-mappings</artifactId>
+        <version>12.0.0-SNAPSHOT</version>
+    </parent>
+    <artifactId>dc-model-html-mapping</artifactId>
+    <packaging>jar</packaging>
+    <properties>
+        <exec.mainClass>de.digitalcollections.model.mappings.html.DcModelHtmlMapping</exec.mainClass>
+    </properties>
+    <name>DigitalCollections: Model (Mappings: HTML)</name>
+    <dependencies>
+        <dependency>
+            <groupId>de.digitalcollections.model</groupId>
+            <artifactId>dc-model</artifactId>
+            <version>12.0.0-SNAPSHOT</version>
+            <type>jar</type>
+        </dependency>
+        <dependency>
+            <groupId>org.jsoup</groupId>
+            <artifactId>jsoup</artifactId>
+            <version>1.15.3</version>
+            <type>jar</type>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>5.6.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <version>5.6.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <version>5.6.0</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/dc-model-mappings/dc-model-html-mapping/pom.xml
+++ b/dc-model-mappings/dc-model-html-mapping/pom.xml
@@ -1,47 +1,49 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <modelVersion>4.0.0</modelVersion>
-    <parent>
-        <groupId>de.digitalcollections.model</groupId>
-        <artifactId>dc-model-mappings</artifactId>
-        <version>12.0.0-SNAPSHOT</version>
-    </parent>
-    <artifactId>dc-model-html-mapping</artifactId>
-    <packaging>jar</packaging>
-    <properties>
-        <exec.mainClass>de.digitalcollections.model.mappings.html.DcModelHtmlMapping</exec.mainClass>
-    </properties>
-    <name>DigitalCollections: Model (Mappings: HTML)</name>
-    <dependencies>
-        <dependency>
-            <groupId>de.digitalcollections.model</groupId>
-            <artifactId>dc-model</artifactId>
-            <version>12.0.0-SNAPSHOT</version>
-            <type>jar</type>
-        </dependency>
-        <dependency>
-            <groupId>org.jsoup</groupId>
-            <artifactId>jsoup</artifactId>
-            <version>1.15.3</version>
-            <type>jar</type>
-        </dependency>
-        <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-api</artifactId>
-            <version>5.6.0</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-params</artifactId>
-            <version>5.6.0</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-engine</artifactId>
-            <version>5.6.0</version>
-            <scope>test</scope>
-        </dependency>
-    </dependencies>
+  <modelVersion>4.0.0</modelVersion>
+  
+  <parent>
+    <groupId>de.digitalcollections.model</groupId>
+    <artifactId>dc-model-mappings</artifactId>
+    <version>12.0.0-SNAPSHOT</version>
+  </parent>
+  
+  <name>DigitalCollections: Model (Mappings: HTML)</name>
+  <artifactId>dc-model-html-mapping</artifactId>
+  <packaging>jar</packaging>
+  
+  <properties>
+    <exec.mainClass>de.digitalcollections.model.mappings.html.DcModelHtmlMapping</exec.mainClass>
+  </properties>
+  
+  <dependencies>
+    <dependency>
+      <groupId>de.digitalcollections.model</groupId>
+      <artifactId>dc-model</artifactId>
+      <version>12.0.0-SNAPSHOT</version>
+    </dependency>
+    <dependency>
+      <groupId>org.jsoup</groupId>
+      <artifactId>jsoup</artifactId>
+      <version>1.15.3</version>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <version>5.6.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <version>5.6.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <version>5.6.0</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
 </project>

--- a/dc-model-mappings/dc-model-html-mapping/src/main/java/de/digitalcollections/model/mappings/html/HtmlMapper.java
+++ b/dc-model-mappings/dc-model-html-mapping/src/main/java/de/digitalcollections/model/mappings/html/HtmlMapper.java
@@ -5,6 +5,7 @@ import de.digitalcollections.model.text.contentblock.BulletList;
 import de.digitalcollections.model.text.contentblock.ContentBlock;
 import de.digitalcollections.model.text.contentblock.ContentBlockNode;
 import de.digitalcollections.model.text.contentblock.ListItem;
+import de.digitalcollections.model.text.contentblock.Mark;
 import de.digitalcollections.model.text.contentblock.Text;
 import java.util.List;
 import org.jsoup.Jsoup;
@@ -20,13 +21,23 @@ public class HtmlMapper {
 
     if (node instanceof Element) {
       Element element = (Element) node;
+      String tagName = element.tagName();
 
-      if ("ul".equalsIgnoreCase(element.tagName())) {
+      if ("ul".equalsIgnoreCase(tagName)) {
         contentBlock = new BulletList();
-      } else if ("li".equalsIgnoreCase(element.tagName())) {
+      } else if ("li".equalsIgnoreCase(tagName)) {
         contentBlock = new ListItem();
+      } else if ("a".equalsIgnoreCase(tagName)) {
+        // TODO only simple plain text links are supported until now; dive into nodes of a-element
+        // for further linked content
+        String text = element.text();
+        contentBlock = new Text(text);
+        String href = element.attr("href");
+        Mark link = new Mark("link");
+        link.addAttribute("href", href);
+        ((Text) contentBlock).addMark(link);
       } else {
-        System.out.println("Unsupported element " + element.tagName() + ": " + node.toString());
+        System.out.println("Unsupported element " + tagName + ": " + node.toString());
       }
 
       if (contentBlock != null

--- a/dc-model-mappings/dc-model-html-mapping/src/main/java/de/digitalcollections/model/mappings/html/HtmlMapper.java
+++ b/dc-model-mappings/dc-model-html-mapping/src/main/java/de/digitalcollections/model/mappings/html/HtmlMapper.java
@@ -27,7 +27,7 @@ import org.jsoup.nodes.TextNode;
  */
 public class HtmlMapper {
 
-  private static ContentBlock getContentBlock(Node node) {
+  public static ContentBlock getContentBlock(Node node) {
     ContentBlock contentBlock = null;
 
     if (node instanceof Element) {
@@ -48,12 +48,11 @@ public class HtmlMapper {
         link.addAttribute("href", href);
         ((Text) contentBlock).addMark(link);
       } else {
-        System.out.println("Unsupported element " + tagName + ": " + node.toString());
+        throw new UnsupportedOperationException(
+            "Not yet implemented: getContentBlock() for HTML element " + tagName);
       }
 
-      if (contentBlock != null
-          && contentBlock instanceof ContentBlockNode
-          && element.childNodeSize() > 0) {
+      if (contentBlock instanceof ContentBlockNode && element.childNodeSize() > 0) {
         List<Node> children = element.childNodes();
         for (Node child : children) {
           ContentBlock childContentBlock = getContentBlock(child);

--- a/dc-model-mappings/dc-model-html-mapping/src/main/java/de/digitalcollections/model/mappings/html/HtmlMapper.java
+++ b/dc-model-mappings/dc-model-html-mapping/src/main/java/de/digitalcollections/model/mappings/html/HtmlMapper.java
@@ -1,0 +1,64 @@
+package de.digitalcollections.model.mappings.html;
+
+import de.digitalcollections.model.text.StructuredContent;
+import de.digitalcollections.model.text.contentblock.BulletList;
+import de.digitalcollections.model.text.contentblock.ContentBlock;
+import de.digitalcollections.model.text.contentblock.ContentBlockNode;
+import de.digitalcollections.model.text.contentblock.ListItem;
+import de.digitalcollections.model.text.contentblock.Text;
+import java.util.List;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.jsoup.nodes.Node;
+import org.jsoup.nodes.TextNode;
+
+public class HtmlMapper {
+
+  private static ContentBlock getContentBlock(Node node) {
+    ContentBlock contentBlock = null;
+
+    if (node instanceof Element) {
+      Element element = (Element) node;
+
+      if ("ul".equalsIgnoreCase(element.tagName())) {
+        contentBlock = new BulletList();
+      } else if ("li".equalsIgnoreCase(element.tagName())) {
+        contentBlock = new ListItem();
+      } else {
+        System.out.println("Unsupported element " + element.tagName() + ": " + node.toString());
+      }
+
+      if (contentBlock != null
+          && contentBlock instanceof ContentBlockNode
+          && element.childNodeSize() > 0) {
+        List<Node> children = element.childNodes();
+        for (Node child : children) {
+          ContentBlock childContentBlock = getContentBlock(child);
+          ((ContentBlockNode) contentBlock).addContentBlock(childContentBlock);
+        }
+      }
+    } else if (node instanceof TextNode) {
+      TextNode textNode = (TextNode) node;
+      contentBlock = new Text(textNode.text());
+    }
+
+    return contentBlock;
+  }
+
+  public static StructuredContent toStructuredContent(String html) {
+    StructuredContent structuredContent = new StructuredContent();
+
+    Document doc = Jsoup.parse(html);
+    Element body = doc.body();
+
+    List<Node> childNodes = body.childNodes();
+
+    for (Node childNode : childNodes) {
+      ContentBlock contentBlock = getContentBlock(childNode);
+      structuredContent.addContentBlock(contentBlock);
+    }
+
+    return structuredContent;
+  }
+}

--- a/dc-model-mappings/dc-model-html-mapping/src/main/java/de/digitalcollections/model/mappings/html/HtmlMapper.java
+++ b/dc-model-mappings/dc-model-html-mapping/src/main/java/de/digitalcollections/model/mappings/html/HtmlMapper.java
@@ -14,6 +14,17 @@ import org.jsoup.nodes.Element;
 import org.jsoup.nodes.Node;
 import org.jsoup.nodes.TextNode;
 
+/**
+ * Mapper for mapping between Digital Collections Model "StructuredContent" and HTML.
+ *
+ * <p>Supports the following HTML elements:
+ *
+ * <ul>
+ *   <li>a (text links only)
+ *   <li>li (list item)
+ *   <li>ul (unordered list)
+ * </ul>
+ */
 public class HtmlMapper {
 
   private static ContentBlock getContentBlock(Node node) {
@@ -57,6 +68,12 @@ public class HtmlMapper {
     return contentBlock;
   }
 
+  /**
+   * Map html to StructuredContent.
+   *
+   * @param html html code to be mapped
+   * @return filled StructuredContent instance
+   */
   public static StructuredContent toStructuredContent(String html) {
     StructuredContent structuredContent = new StructuredContent();
 

--- a/dc-model-mappings/dc-model-html-mapping/src/test/java/de/digitalcollections/model/mappings/html/HtmlMapperTest.java
+++ b/dc-model-mappings/dc-model-html-mapping/src/test/java/de/digitalcollections/model/mappings/html/HtmlMapperTest.java
@@ -8,14 +8,6 @@ import org.junit.jupiter.api.Test;
 public class HtmlMapperTest {
 
   @Test
-  public void testHtml2StructuredContentSimpleUnorderedList() {
-    String html = "<ul><li>item 1</li><li>item 2</li></ul>";
-
-    StructuredContent sc = HtmlMapper.toStructuredContent(html);
-    assertEquals(1, sc.getContentBlocks().size());
-  }
-
-  @Test
   public void testHtml2StructuredContentHierarchicalUnorderedList() {
     String html =
         "<ul>"
@@ -30,5 +22,25 @@ public class HtmlMapperTest {
 
     StructuredContent sc = HtmlMapper.toStructuredContent(html);
     assertEquals(1, sc.getContentBlocks().size());
+    // TODO better assert
+  }
+
+  @Test
+  public void testHtml2StructuredContentSimpleUnorderedList() {
+    String html = "<ul><li>item 1</li><li>item 2</li></ul>";
+
+    StructuredContent sc = HtmlMapper.toStructuredContent(html);
+    assertEquals(1, sc.getContentBlocks().size());
+    // TODO better assert
+  }
+
+  @Test
+  public void testHtml2StructuredContentSimpleUnorderedListWithLinks() {
+    String html =
+        "<ul><li>item 1</li><li>Test <a href=\"https://mdz-nbn-resolving.de/view:bsb00009405?page=297\">Erscheinungsjahr: 1956, aufgeführt in ZBLG 22 (1959), Nr.2082</a> Test</li></ul>";
+
+    StructuredContent sc = HtmlMapper.toStructuredContent(html);
+    assertEquals(1, sc.getContentBlocks().size());
+    // TODO better assert
   }
 }

--- a/dc-model-mappings/dc-model-html-mapping/src/test/java/de/digitalcollections/model/mappings/html/HtmlMapperTest.java
+++ b/dc-model-mappings/dc-model-html-mapping/src/test/java/de/digitalcollections/model/mappings/html/HtmlMapperTest.java
@@ -1,0 +1,34 @@
+package de.digitalcollections.model.mappings.html;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import de.digitalcollections.model.text.StructuredContent;
+import org.junit.jupiter.api.Test;
+
+public class HtmlMapperTest {
+
+  @Test
+  public void testHtml2StructuredContentSimpleUnorderedList() {
+    String html = "<ul><li>item 1</li><li>item 2</li></ul>";
+
+    StructuredContent sc = HtmlMapper.toStructuredContent(html);
+    assertEquals(1, sc.getContentBlocks().size());
+  }
+
+  @Test
+  public void testHtml2StructuredContentHierarchicalUnorderedList() {
+    String html =
+        "<ul>"
+            + "<li>item 1"
+            + "  <ul>"
+            + "  <li>item 1.1</li>"
+            + "  <li>item 1.2</li>"
+            + "  </ul>"
+            + "</li>"
+            + "<li>item 2</li>"
+            + "</ul>";
+
+    StructuredContent sc = HtmlMapper.toStructuredContent(html);
+    assertEquals(1, sc.getContentBlocks().size());
+  }
+}

--- a/dc-model-mappings/dc-model-html-mapping/src/test/java/de/digitalcollections/model/mappings/html/HtmlMapperTest.java
+++ b/dc-model-mappings/dc-model-html-mapping/src/test/java/de/digitalcollections/model/mappings/html/HtmlMapperTest.java
@@ -1,8 +1,10 @@
 package de.digitalcollections.model.mappings.html;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import de.digitalcollections.model.text.StructuredContent;
+import org.jsoup.nodes.Element;
 import org.junit.jupiter.api.Test;
 
 public class HtmlMapperTest {
@@ -42,5 +44,14 @@ public class HtmlMapperTest {
     StructuredContent sc = HtmlMapper.toStructuredContent(html);
     assertEquals(1, sc.getContentBlocks().size());
     // TODO better assert
+  }
+
+  @Test
+  public void testGetContentBlockForUnsupportedElement() {
+    assertThrows(
+        UnsupportedOperationException.class,
+        () -> {
+          HtmlMapper.getContentBlock(new Element("blabla"));
+        });
   }
 }

--- a/dc-model-mappings/pom.xml
+++ b/dc-model-mappings/pom.xml
@@ -1,15 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <modelVersion>4.0.0</modelVersion>
-    <parent>
-        <groupId>de.digitalcollections.model</groupId>
-        <artifactId>dc-model-parent</artifactId>
-        <version>12.0.0-SNAPSHOT</version>
-    </parent>
-    <artifactId>dc-model-mappings</artifactId>
-    <packaging>pom</packaging>
-    <name>DigitalCollections: Model (Mappings)</name>
-    <modules>
-        <module>dc-model-html-mapping</module>
-    </modules>
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>de.digitalcollections.model</groupId>
+    <artifactId>dc-model-parent</artifactId>
+    <version>12.0.0-SNAPSHOT</version>
+  </parent>
+
+  <name>DigitalCollections: Model (Mappings)</name>
+  <artifactId>dc-model-mappings</artifactId>
+  <packaging>pom</packaging>
+
+  <modules>
+    <module>dc-model-html-mapping</module>
+  </modules>
 </project>

--- a/dc-model-mappings/pom.xml
+++ b/dc-model-mappings/pom.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>de.digitalcollections.model</groupId>
+        <artifactId>dc-model-parent</artifactId>
+        <version>12.0.0-SNAPSHOT</version>
+    </parent>
+    <artifactId>dc-model-mappings</artifactId>
+    <packaging>pom</packaging>
+    <name>DigitalCollections: Model (Mappings)</name>
+    <modules>
+        <module>dc-model-html-mapping</module>
+    </modules>
+</project>

--- a/dc-model/src/main/java/de/digitalcollections/model/identifiable/Identifiable.java
+++ b/dc-model/src/main/java/de/digitalcollections/model/identifiable/Identifiable.java
@@ -61,6 +61,14 @@ public class Identifiable extends UniqueObject {
     identifiers.add(Objects.requireNonNull(identifier));
   }
 
+  public void addLocalizedUrlAlias(UrlAlias urlAlias) {
+    if (localizedUrlAliases == null) {
+      localizedUrlAliases = new LocalizedUrlAliases(urlAlias);
+    } else {
+      localizedUrlAliases.add(urlAlias);
+    }
+  }
+
   public void addTag(Tag tag) {
     if (tags == null) {
       tags = new HashSet<>(1);

--- a/pom.xml
+++ b/pom.xml
@@ -11,6 +11,7 @@
   <modules>
     <module>dc-model</module>
     <module>dc-model-jackson</module>
+    <module>dc-model-mappings</module>
   </modules>
 
   <name>DigitalCollections: Model</name>


### PR DESCRIPTION
- adds module "mapping" with submodule "html" for mapping HTML code (currently supporting ul, li, a) to DC-Model StructuredContent
- add convenience method addLocalizedUrlAlias(UrlAlias urlAlias) to Identifiable