### PR TITLE
publisher-related fixes

### DIFF
--- a/dc-model-jackson/src/main/java/de/digitalcollections/model/jackson/mixin/identifiable/entity/manifestation/DistributionInfoMixIn.java
+++ b/dc-model-jackson/src/main/java/de/digitalcollections/model/jackson/mixin/identifiable/entity/manifestation/DistributionInfoMixIn.java
@@ -1,5 +1,6 @@
 package de.digitalcollections.model.jackson.mixin.identifiable.entity.manifestation;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -8,4 +9,8 @@ import de.digitalcollections.model.identifiable.entity.manifestation.Distributio
 @JsonDeserialize(as = DistributionInfo.class)
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonTypeName("DISTRIBUTION_INFO")
-public interface DistributionInfoMixIn {}
+public interface DistributionInfoMixIn {
+
+  @JsonIgnore
+  public boolean isEmpty();
+}

--- a/dc-model-jackson/src/main/java/de/digitalcollections/model/jackson/mixin/identifiable/entity/manifestation/ProductionInfoMixIn.java
+++ b/dc-model-jackson/src/main/java/de/digitalcollections/model/jackson/mixin/identifiable/entity/manifestation/ProductionInfoMixIn.java
@@ -1,5 +1,6 @@
 package de.digitalcollections.model.jackson.mixin.identifiable.entity.manifestation;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -8,4 +9,8 @@ import de.digitalcollections.model.identifiable.entity.manifestation.ProductionI
 @JsonDeserialize(as = ProductionInfo.class)
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonTypeName("PRODUCTION_INFO")
-public interface ProductionInfoMixIn {}
+public interface ProductionInfoMixIn {
+
+  @JsonIgnore
+  public boolean isEmpty();
+}

--- a/dc-model-jackson/src/main/java/de/digitalcollections/model/jackson/mixin/identifiable/entity/manifestation/PublicationInfoMixIn.java
+++ b/dc-model-jackson/src/main/java/de/digitalcollections/model/jackson/mixin/identifiable/entity/manifestation/PublicationInfoMixIn.java
@@ -1,5 +1,6 @@
 package de.digitalcollections.model.jackson.mixin.identifiable.entity.manifestation;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -8,4 +9,8 @@ import de.digitalcollections.model.identifiable.entity.manifestation.Publication
 @JsonDeserialize(as = PublicationInfo.class)
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonTypeName("PUBLICATION_INFO")
-public interface PublicationInfoMixIn {}
+public interface PublicationInfoMixIn {
+
+  @JsonIgnore
+  public boolean isEmpty();
+}

--- a/dc-model-jackson/src/main/java/de/digitalcollections/model/jackson/mixin/identifiable/entity/manifestation/PublisherMixIn.java
+++ b/dc-model-jackson/src/main/java/de/digitalcollections/model/jackson/mixin/identifiable/entity/manifestation/PublisherMixIn.java
@@ -1,11 +1,14 @@
 package de.digitalcollections.model.jackson.mixin.identifiable.entity.manifestation;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import de.digitalcollections.model.identifiable.entity.manifestation.Publisher;
 
 @JsonDeserialize(as = Publisher.class)
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonTypeInfo(use = Id.NAME, property = "objectType")
 @JsonTypeName("PUBLISHER")
 public interface PublisherMixIn {}

--- a/dc-model-jackson/src/test/java/de/digitalcollections/model/jackson/mixin/identifiable/entity/manifestation/DistributionInfoMixInTest.java
+++ b/dc-model-jackson/src/test/java/de/digitalcollections/model/jackson/mixin/identifiable/entity/manifestation/DistributionInfoMixInTest.java
@@ -1,0 +1,46 @@
+package de.digitalcollections.model.jackson.mixin.identifiable.entity.manifestation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import de.digitalcollections.model.identifiable.entity.agent.CorporateBody;
+import de.digitalcollections.model.identifiable.entity.geo.location.HumanSettlement;
+import de.digitalcollections.model.identifiable.entity.manifestation.DistributionInfo;
+import de.digitalcollections.model.identifiable.entity.manifestation.Publisher;
+import de.digitalcollections.model.jackson.DigitalCollectionsObjectMapper;
+import de.digitalcollections.model.text.LocalizedText;
+import java.util.Locale;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("The DistributionInfo MixIn")
+class DistributionInfoMixInTest {
+
+  @DisplayName("does not serialize the 'empty' field")
+  @Test
+  public void doesNotSerializeEmpty() throws JsonProcessingException {
+    ObjectMapper objectMapper = new DigitalCollectionsObjectMapper();
+
+    DistributionInfo distributionInfo =
+        DistributionInfo.builder()
+            .publisher(
+                Publisher.builder()
+                    .location(
+                        HumanSettlement.builder()
+                            .name(new LocalizedText(Locale.GERMAN, "München"))
+                            .build())
+                    .agent(
+                        CorporateBody.builder()
+                            .name(new LocalizedText(Locale.GERMAN, "Acme Inc."))
+                            .build())
+                    .build())
+            .datePresentation("1929-1931")
+            .build();
+
+    String json =
+        objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(distributionInfo);
+
+    assertThat(json).doesNotContain("empty");
+  }
+}

--- a/dc-model-jackson/src/test/java/de/digitalcollections/model/jackson/mixin/identifiable/entity/manifestation/ProductionInfoMixInTest.java
+++ b/dc-model-jackson/src/test/java/de/digitalcollections/model/jackson/mixin/identifiable/entity/manifestation/ProductionInfoMixInTest.java
@@ -1,0 +1,45 @@
+package de.digitalcollections.model.jackson.mixin.identifiable.entity.manifestation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import de.digitalcollections.model.identifiable.entity.agent.CorporateBody;
+import de.digitalcollections.model.identifiable.entity.geo.location.HumanSettlement;
+import de.digitalcollections.model.identifiable.entity.manifestation.ProductionInfo;
+import de.digitalcollections.model.identifiable.entity.manifestation.Publisher;
+import de.digitalcollections.model.jackson.DigitalCollectionsObjectMapper;
+import de.digitalcollections.model.text.LocalizedText;
+import java.util.Locale;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("The ProductionInfo MixIn")
+class ProductionInfoMixInTest {
+
+  @DisplayName("does not serialize the 'empty' field")
+  @Test
+  public void doesNotSerializeEmpty() throws JsonProcessingException {
+    ObjectMapper objectMapper = new DigitalCollectionsObjectMapper();
+
+    ProductionInfo productionInfo =
+        ProductionInfo.builder()
+            .publisher(
+                Publisher.builder()
+                    .location(
+                        HumanSettlement.builder()
+                            .name(new LocalizedText(Locale.GERMAN, "München"))
+                            .build())
+                    .agent(
+                        CorporateBody.builder()
+                            .name(new LocalizedText(Locale.GERMAN, "Acme Inc."))
+                            .build())
+                    .build())
+            .datePresentation("1929-1931")
+            .build();
+
+    String json = objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(productionInfo);
+
+    assertThat(json).doesNotContain("empty");
+  }
+}

--- a/dc-model-jackson/src/test/java/de/digitalcollections/model/jackson/mixin/identifiable/entity/manifestation/PublicationInfoMixInTest.java
+++ b/dc-model-jackson/src/test/java/de/digitalcollections/model/jackson/mixin/identifiable/entity/manifestation/PublicationInfoMixInTest.java
@@ -1,0 +1,45 @@
+package de.digitalcollections.model.jackson.mixin.identifiable.entity.manifestation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import de.digitalcollections.model.identifiable.entity.agent.CorporateBody;
+import de.digitalcollections.model.identifiable.entity.geo.location.HumanSettlement;
+import de.digitalcollections.model.identifiable.entity.manifestation.PublicationInfo;
+import de.digitalcollections.model.identifiable.entity.manifestation.Publisher;
+import de.digitalcollections.model.jackson.DigitalCollectionsObjectMapper;
+import de.digitalcollections.model.text.LocalizedText;
+import java.util.Locale;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("The PublicationInfo MixIn")
+class PublicationInfoMixInTest {
+
+  @DisplayName("does not serialize the 'empty' field")
+  @Test
+  public void doesNotSerializeEmpty() throws JsonProcessingException {
+    ObjectMapper objectMapper = new DigitalCollectionsObjectMapper();
+
+    PublicationInfo publicationInfo =
+        PublicationInfo.builder()
+            .publisher(
+                Publisher.builder()
+                    .location(
+                        HumanSettlement.builder()
+                            .name(new LocalizedText(Locale.GERMAN, "München"))
+                            .build())
+                    .agent(
+                        CorporateBody.builder()
+                            .name(new LocalizedText(Locale.GERMAN, "Acme Inc."))
+                            .build())
+                    .build())
+            .datePresentation("1929-1931")
+            .build();
+
+    String json = objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(publicationInfo);
+
+    assertThat(json).doesNotContain("empty");
+  }
+}

--- a/dc-model-jackson/src/test/resources/serializedTestObjects/identifiable/entity/manifestation/DistributionInfo.json
+++ b/dc-model-jackson/src/test/resources/serializedTestObjects/identifiable/entity/manifestation/DistributionInfo.json
@@ -177,6 +177,5 @@
       "timezoneOffset" : 0,
       "year" : 2020
     }
-  },
-  "empty" : false
+  }
 }

--- a/dc-model-jackson/src/test/resources/serializedTestObjects/identifiable/entity/manifestation/Manifestation.json
+++ b/dc-model-jackson/src/test/resources/serializedTestObjects/identifiable/entity/manifestation/Manifestation.json
@@ -269,8 +269,7 @@
         "timezoneOffset" : 0,
         "year" : 2020
       }
-    },
-    "empty" : false
+    }
   },
   "scale" : "[Ca. 1:820 000]",
   "subjects" : [ {

--- a/dc-model-jackson/src/test/resources/serializedTestObjects/identifiable/entity/manifestation/ProductionInfo.json
+++ b/dc-model-jackson/src/test/resources/serializedTestObjects/identifiable/entity/manifestation/ProductionInfo.json
@@ -177,6 +177,5 @@
       "timezoneOffset" : 0,
       "year" : 2020
     }
-  },
-  "empty" : false
+  }
 }

--- a/dc-model-jackson/src/test/resources/serializedTestObjects/identifiable/entity/manifestation/PublicationInfo.json
+++ b/dc-model-jackson/src/test/resources/serializedTestObjects/identifiable/entity/manifestation/PublicationInfo.json
@@ -177,6 +177,5 @@
       "timezoneOffset" : 0,
       "year" : 2020
     }
-  },
-  "empty" : false
+  }
 }

--- a/dc-model/src/main/java/de/digitalcollections/model/identifiable/entity/manifestation/Publisher.java
+++ b/dc-model/src/main/java/de/digitalcollections/model/identifiable/entity/manifestation/Publisher.java
@@ -1,6 +1,5 @@
 package de.digitalcollections.model.identifiable.entity.manifestation;
 
-import de.digitalcollections.model.UniqueObject;
 import de.digitalcollections.model.identifiable.entity.agent.Agent;
 import de.digitalcollections.model.identifiable.entity.geo.location.HumanSettlement;
 import java.util.ArrayList;
@@ -20,7 +19,7 @@ import lombok.experimental.SuperBuilder;
  * dependencies in Cologne and Berlin and was active between 1994 and 1998.
  */
 @SuperBuilder(buildMethodName = "prebuild")
-public class Publisher extends UniqueObject {
+public class Publisher {
 
   private List<HumanSettlement> locations;
   private Agent agent;
@@ -119,19 +118,14 @@ public class Publisher extends UniqueObject {
         + datePresentation
         + '\''
         + '\''
-        + ", uuid="
-        + uuid
         + '}';
   }
 
   public abstract static class PublisherBuilder<
-          C extends Publisher, B extends PublisherBuilder<C, B>>
-      extends UniqueObjectBuilder<C, B> {
+      C extends Publisher, B extends PublisherBuilder<C, B>> {
 
-    @Override
     public C build() {
       C c = prebuild();
-      c.init();
       return c;
     }
 


### PR DESCRIPTION
- `Publisher` is no longer a UniqueObject
- Removed serialization of `empty` flag of `PublishingInfo` derivatives